### PR TITLE
feat: add meal plan page with weekly view

### DIFF
--- a/backend/app/api/__init__.py
+++ b/backend/app/api/__init__.py
@@ -4,6 +4,6 @@ API Routers
 Import all API routers for easy access.
 """
 
-from app.api import users, recipes, libraries, sharing, chat, feedback
+from app.api import users, recipes, libraries, sharing, chat, feedback, meal_plans
 
-__all__ = ["users", "recipes", "libraries", "sharing", "chat", "feedback"]
+__all__ = ["users", "recipes", "libraries", "sharing", "chat", "feedback", "meal_plans"]

--- a/backend/app/api/meal_plans.py
+++ b/backend/app/api/meal_plans.py
@@ -1,0 +1,177 @@
+"""
+Meal Plans API
+
+API endpoints for meal plan operations.
+"""
+
+from typing import Annotated
+from datetime import date, timedelta
+from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database import get_db
+from app.models.recipe import Recipe
+from app.schemas.meal_plan import (
+    MealPlanResponse,
+    MealPlanEntryResponse,
+    MealPlanEntryUpsert,
+    RecipeRef,
+)
+from app.services.meal_plan_service import (
+    get_or_create_meal_plan,
+    get_plan_by_id,
+    upsert_meal_plan_entry,
+    delete_meal_plan_entry,
+    VALID_MEAL_TYPES,
+)
+from app.utils.dependencies import CurrentUser
+
+router = APIRouter(prefix="/meal-plans", tags=["meal-plans"])
+
+
+def _build_entry_response(e: object) -> MealPlanEntryResponse:
+    """Build a MealPlanEntryResponse from a MealPlanEntry model instance."""
+    from app.models.meal_plan import MealPlanEntry as MealPlanEntryModel
+
+    assert isinstance(e, MealPlanEntryModel)
+    return MealPlanEntryResponse(
+        id=e.id,
+        day_of_week=e.day_of_week,
+        meal_type=e.meal_type,
+        recipe=(
+            RecipeRef(
+                id=e.recipe.id,
+                title=e.recipe.title,
+                cook_time_minutes=e.recipe.cook_time_minutes,
+            )
+            if e.recipe
+            else None
+        ),
+    )
+
+
+def _build_response(plan: object) -> MealPlanResponse:
+    """Build a MealPlanResponse from a MealPlan model instance."""
+    from app.models.meal_plan import MealPlan as MealPlanModel
+
+    assert isinstance(plan, MealPlanModel)
+
+    entries = [_build_entry_response(e) for e in plan.entries]
+
+    return MealPlanResponse(
+        id=plan.id,
+        week_start=str(plan.week_start_date),
+        entries=entries,
+        created_at=plan.created_at.isoformat(),
+        updated_at=plan.updated_at.isoformat(),
+    )
+
+
+@router.get("/current", response_model=MealPlanResponse)
+async def get_current_meal_plan(
+    db: Annotated[AsyncSession, Depends(get_db)],
+    current_user: CurrentUser,
+) -> MealPlanResponse:
+    """Get meal plan for the current week, auto-creating if none exists."""
+    today = date.today()
+    plan = await get_or_create_meal_plan(db, current_user.id, today)
+    return _build_response(plan)
+
+
+@router.get("", response_model=MealPlanResponse)
+async def get_meal_plan(
+    db: Annotated[AsyncSession, Depends(get_db)],
+    current_user: CurrentUser,
+    week_start: date = Query(..., description="Week start date (YYYY-MM-DD)"),
+) -> MealPlanResponse:
+    """Get meal plan for a given week, auto-creating if none exists."""
+    plan = await get_or_create_meal_plan(db, current_user.id, week_start)
+    return _build_response(plan)
+
+
+@router.put("/{plan_id}/entries", response_model=MealPlanEntryResponse)
+async def upsert_entry(
+    plan_id: str,
+    body: MealPlanEntryUpsert,
+    db: Annotated[AsyncSession, Depends(get_db)],
+    current_user: CurrentUser,
+) -> MealPlanEntryResponse:
+    """Upsert a meal plan entry (assign recipe to a meal slot)."""
+    # Validate meal_type
+    if body.meal_type not in VALID_MEAL_TYPES:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"Invalid meal_type '{body.meal_type}'. Must be one of: {sorted(VALID_MEAL_TYPES)}",
+        )
+
+    # Find plan
+    plan = await get_plan_by_id(db, plan_id)
+    if plan is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Meal plan not found"
+        )
+
+    # Ownership check
+    if plan.user_id != current_user.id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail="Not your meal plan"
+        )
+
+    # Parse and validate date is within the plan's week
+    try:
+        entry_date = date.fromisoformat(body.date)
+    except ValueError:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="Invalid date format",
+        )
+
+    week_start = plan.week_start_date
+    week_end = week_start + timedelta(days=6)
+    if entry_date < week_start or entry_date > week_end:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"Date {body.date} is outside the plan week ({week_start} to {week_end})",
+        )
+
+    # Validate recipe exists
+    recipe = await db.get(Recipe, body.recipe_id)
+    if recipe is None:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="Recipe not found",
+        )
+
+    day_of_week = (entry_date - week_start).days
+    entry = await upsert_meal_plan_entry(
+        db, plan, day_of_week, body.meal_type, body.recipe_id
+    )
+    return _build_entry_response(entry)
+
+
+@router.delete("/{plan_id}/entries/{entry_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_entry(
+    plan_id: str,
+    entry_id: str,
+    db: Annotated[AsyncSession, Depends(get_db)],
+    current_user: CurrentUser,
+) -> Response:
+    """Delete a meal plan entry."""
+    plan = await get_plan_by_id(db, plan_id)
+    if plan is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Meal plan not found"
+        )
+
+    if plan.user_id != current_user.id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail="Not your meal plan"
+        )
+
+    entry = await delete_meal_plan_entry(db, plan, entry_id)
+    if entry is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Entry not found"
+        )
+
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -16,7 +16,7 @@ import logging
 import traceback
 
 from app.config import settings
-from app.api import users, recipes, libraries, sharing, chat, feedback
+from app.api import users, recipes, libraries, sharing, chat, feedback, meal_plans
 
 # Initialize Sentry if DSN is configured
 if settings.sentry_dsn:
@@ -97,6 +97,7 @@ app.include_router(libraries.router, prefix="/api/v1")
 app.include_router(sharing.router, prefix="/api/v1")
 app.include_router(chat.router, prefix="/api/v1")
 app.include_router(feedback.router, prefix="/api/v1")
+app.include_router(meal_plans.router, prefix="/api/v1")
 
 
 # Mount static files for frontend assets (JS, CSS, images)

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -9,6 +9,7 @@ from app.models.recipe import Recipe, DifficultyLevel
 from app.models.library import RecipeLibrary
 from app.models.share import RecipeShare, SharePermission
 from app.models.feedback import Feedback
+from app.models.meal_plan import MealPlan, MealPlanEntry
 
 __all__ = [
     "User",
@@ -18,4 +19,6 @@ __all__ = [
     "RecipeShare",
     "SharePermission",
     "Feedback",
+    "MealPlan",
+    "MealPlanEntry",
 ]

--- a/backend/app/models/meal_plan.py
+++ b/backend/app/models/meal_plan.py
@@ -1,0 +1,63 @@
+"""
+Meal Plan Model
+
+Database models for weekly meal plans and their entries.
+"""
+
+from sqlalchemy import String, Integer, Date, ForeignKey, UniqueConstraint
+from sqlalchemy.orm import relationship, Mapped, mapped_column
+from datetime import datetime, date
+import uuid
+
+from app.database import Base
+
+
+class MealPlan(Base):
+    """Weekly meal plan for a user."""
+
+    __tablename__ = "meal_plans"
+    __table_args__ = (
+        UniqueConstraint("user_id", "week_start_date", name="uq_user_week"),
+    )
+
+    id: Mapped[str] = mapped_column(
+        String(36), primary_key=True, default=lambda: str(uuid.uuid4())
+    )
+    user_id: Mapped[str] = mapped_column(
+        String(36), ForeignKey("users.id"), nullable=False, index=True
+    )
+    week_start_date: Mapped[date] = mapped_column(Date, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(default=datetime.utcnow)
+    updated_at: Mapped[datetime] = mapped_column(
+        default=datetime.utcnow, onupdate=datetime.utcnow
+    )
+
+    entries: Mapped[list["MealPlanEntry"]] = relationship(
+        back_populates="meal_plan", cascade="all, delete-orphan"
+    )
+
+
+class MealPlanEntry(Base):
+    """Single entry in a meal plan (one meal slot)."""
+
+    __tablename__ = "meal_plan_entries"
+    __table_args__ = (
+        UniqueConstraint(
+            "meal_plan_id", "day_of_week", "meal_type", name="uq_plan_day_meal"
+        ),
+    )
+
+    id: Mapped[str] = mapped_column(
+        String(36), primary_key=True, default=lambda: str(uuid.uuid4())
+    )
+    meal_plan_id: Mapped[str] = mapped_column(
+        String(36), ForeignKey("meal_plans.id"), nullable=False, index=True
+    )
+    day_of_week: Mapped[int] = mapped_column(Integer, nullable=False)
+    meal_type: Mapped[str] = mapped_column(String(20), nullable=False)
+    recipe_id: Mapped[str | None] = mapped_column(
+        String(36), ForeignKey("recipes.id", ondelete="SET NULL"), nullable=True
+    )
+
+    meal_plan: Mapped["MealPlan"] = relationship(back_populates="entries")
+    recipe = relationship("Recipe", lazy="joined")

--- a/backend/app/schemas/meal_plan.py
+++ b/backend/app/schemas/meal_plan.py
@@ -1,0 +1,47 @@
+"""
+Meal Plan Schemas
+
+Pydantic schemas for meal plan data validation and serialization.
+"""
+
+from pydantic import BaseModel, ConfigDict
+from typing import Optional
+
+
+class RecipeRef(BaseModel):
+    """Minimal recipe reference within a meal plan entry."""
+
+    id: str
+    title: str
+    cook_time_minutes: Optional[int] = None
+
+
+class MealPlanEntryResponse(BaseModel):
+    """Response schema for a meal plan entry."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: str
+    day_of_week: int
+    meal_type: str
+    recipe: Optional[RecipeRef] = None
+
+
+class MealPlanEntryUpsert(BaseModel):
+    """Request schema for upserting a meal plan entry."""
+
+    date: str
+    meal_type: str
+    recipe_id: str
+
+
+class MealPlanResponse(BaseModel):
+    """Response schema for a meal plan."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: str
+    week_start: str
+    entries: list[MealPlanEntryResponse]
+    created_at: str
+    updated_at: str

--- a/backend/app/services/meal_plan_service.py
+++ b/backend/app/services/meal_plan_service.py
@@ -1,0 +1,120 @@
+"""
+Meal Plan Service
+
+Business logic for meal plan operations.
+"""
+
+from datetime import date, timedelta
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from app.models.meal_plan import MealPlan, MealPlanEntry
+
+
+VALID_MEAL_TYPES = {"breakfast", "lunch", "dinner", "snack"}
+
+
+def snap_to_monday(d: date) -> date:
+    """Snap a date to the previous Monday (or itself if already Monday)."""
+    return d - timedelta(days=d.weekday())
+
+
+async def get_or_create_meal_plan(
+    db: AsyncSession, user_id: str, week_start: date
+) -> MealPlan:
+    """Get existing meal plan or create a new empty one."""
+    monday = snap_to_monday(week_start)
+
+    result = await db.execute(
+        select(MealPlan)
+        .options(selectinload(MealPlan.entries).joinedload(MealPlanEntry.recipe))
+        .where(MealPlan.user_id == user_id, MealPlan.week_start_date == monday)
+    )
+    plan = result.scalar_one_or_none()
+
+    if plan is None:
+        plan = MealPlan(user_id=user_id, week_start_date=monday)
+        db.add(plan)
+        await db.flush()
+        # Re-fetch with eager loading to avoid lazy load issues
+        result = await db.execute(
+            select(MealPlan)
+            .options(selectinload(MealPlan.entries).joinedload(MealPlanEntry.recipe))
+            .where(MealPlan.id == plan.id)
+        )
+        plan = result.scalar_one()
+
+    return plan
+
+
+async def get_plan_by_id(db: AsyncSession, plan_id: str) -> MealPlan | None:
+    """Get a meal plan by ID with entries eagerly loaded."""
+    result = await db.execute(
+        select(MealPlan)
+        .options(selectinload(MealPlan.entries).joinedload(MealPlanEntry.recipe))
+        .where(MealPlan.id == plan_id)
+    )
+    return result.scalar_one_or_none()
+
+
+async def upsert_meal_plan_entry(
+    db: AsyncSession,
+    plan: MealPlan,
+    day_of_week: int,
+    meal_type: str,
+    recipe_id: str,
+) -> MealPlanEntry:
+    """Create or update a meal plan entry for a given day/meal slot."""
+    # Check for existing entry with same day_of_week + meal_type
+    result = await db.execute(
+        select(MealPlanEntry).where(
+            MealPlanEntry.meal_plan_id == plan.id,
+            MealPlanEntry.day_of_week == day_of_week,
+            MealPlanEntry.meal_type == meal_type,
+        )
+    )
+    entry = result.scalar_one_or_none()
+
+    if entry is not None:
+        entry.recipe_id = recipe_id
+    else:
+        entry = MealPlanEntry(
+            meal_plan_id=plan.id,
+            day_of_week=day_of_week,
+            meal_type=meal_type,
+            recipe_id=recipe_id,
+        )
+        db.add(entry)
+
+    await db.flush()
+
+    # Re-fetch with recipe joined
+    from sqlalchemy.orm import joinedload
+
+    result = await db.execute(
+        select(MealPlanEntry)
+        .options(joinedload(MealPlanEntry.recipe))
+        .where(MealPlanEntry.id == entry.id)
+    )
+    entry = result.scalar_one()
+    return entry
+
+
+async def delete_meal_plan_entry(
+    db: AsyncSession, plan: MealPlan, entry_id: str
+) -> MealPlanEntry | None:
+    """Delete a meal plan entry. Returns the entry if found, None otherwise."""
+    result = await db.execute(
+        select(MealPlanEntry).where(
+            MealPlanEntry.id == entry_id,
+            MealPlanEntry.meal_plan_id == plan.id,
+        )
+    )
+    entry = result.scalar_one_or_none()
+    if entry is not None:
+        await db.delete(entry)
+        await db.flush()
+        # Expire all cached objects so collections are refreshed on next access
+        db.expire_all()
+    return entry

--- a/backend/migrations/versions/a7dbfcb12232_create_meal_plan_tables.py
+++ b/backend/migrations/versions/a7dbfcb12232_create_meal_plan_tables.py
@@ -1,0 +1,61 @@
+"""create_meal_plan_tables
+
+Revision ID: a7dbfcb12232
+Revises: b2c3d4e5f6g7
+Create Date: 2026-01-28 22:50:03.084347
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = "a7dbfcb12232"
+down_revision: Union[str, None] = "b2c3d4e5f6g7"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "meal_plans",
+        sa.Column("id", sa.String(length=36), nullable=False),
+        sa.Column("user_id", sa.String(length=36), nullable=False),
+        sa.Column("week_start_date", sa.Date(), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"]),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("user_id", "week_start_date", name="uq_user_week"),
+    )
+    op.create_index("ix_meal_plans_user_id", "meal_plans", ["user_id"], unique=False)
+
+    op.create_table(
+        "meal_plan_entries",
+        sa.Column("id", sa.String(length=36), nullable=False),
+        sa.Column("meal_plan_id", sa.String(length=36), nullable=False),
+        sa.Column("day_of_week", sa.Integer(), nullable=False),
+        sa.Column("meal_type", sa.String(length=20), nullable=False),
+        sa.Column("recipe_id", sa.String(length=36), nullable=True),
+        sa.ForeignKeyConstraint(["meal_plan_id"], ["meal_plans.id"]),
+        sa.ForeignKeyConstraint(["recipe_id"], ["recipes.id"], ondelete="SET NULL"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "meal_plan_id", "day_of_week", "meal_type", name="uq_plan_day_meal"
+        ),
+    )
+    op.create_index(
+        "ix_meal_plan_entries_meal_plan_id",
+        "meal_plan_entries",
+        ["meal_plan_id"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_meal_plan_entries_meal_plan_id", table_name="meal_plan_entries")
+    op.drop_table("meal_plan_entries")
+    op.drop_index("ix_meal_plans_user_id", table_name="meal_plans")
+    op.drop_table("meal_plans")

--- a/backend/tests/integration/test_meal_plans_api.py
+++ b/backend/tests/integration/test_meal_plans_api.py
@@ -1,0 +1,557 @@
+"""
+Integration Tests for Meal Plans API
+
+Tests for GET /api/v1/meal-plans endpoint: fetching meal plans,
+auto-creation, week snapping, ownership, and auth.
+"""
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+
+class TestGetMealPlan:
+    """Tests for GET /api/v1/meal-plans?week_start=YYYY-MM-DD."""
+
+    @pytest.mark.asyncio
+    async def test_get_meal_plan_auto_creates_empty_plan(
+        self,
+        client: AsyncClient,
+        auth_headers: dict,
+        test_user,
+    ):
+        """GET with no existing plan should auto-create and return 200 with empty entries."""
+        response = await client.get(
+            "/api/v1/meal-plans",
+            headers=auth_headers,
+            params={"week_start": "2025-01-06"},  # A Monday
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["week_start"] == "2025-01-06"
+        assert data["entries"] == []
+        assert "id" in data
+
+    @pytest.mark.asyncio
+    async def test_get_meal_plan_returns_existing_plan_with_entries(
+        self,
+        client: AsyncClient,
+        auth_headers: dict,
+        test_user,
+        test_recipe,
+        test_db: AsyncSession,
+    ):
+        """GET returns 200 with plan and entries for an existing week."""
+        # First call auto-creates the plan
+        create_response = await client.get(
+            "/api/v1/meal-plans",
+            headers=auth_headers,
+            params={"week_start": "2025-01-06"},
+        )
+        assert create_response.status_code == 200
+        plan_id = create_response.json()["id"]
+
+        # TODO: Once POST entries endpoint exists, add an entry here.
+        # For now, verify the plan is returned on second GET.
+        response = await client.get(
+            "/api/v1/meal-plans",
+            headers=auth_headers,
+            params={"week_start": "2025-01-06"},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["id"] == plan_id
+        assert "entries" in data
+
+    @pytest.mark.asyncio
+    async def test_get_meal_plan_snaps_non_monday_to_monday(
+        self,
+        client: AsyncClient,
+        auth_headers: dict,
+        test_user,
+    ):
+        """GET with a Wednesday date should snap to the previous Monday."""
+        # 2025-01-08 is a Wednesday; should snap to 2025-01-06 (Monday)
+        response = await client.get(
+            "/api/v1/meal-plans",
+            headers=auth_headers,
+            params={"week_start": "2025-01-08"},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["week_start"] == "2025-01-06"
+
+    @pytest.mark.asyncio
+    async def test_get_meal_plan_unauthenticated_returns_401(
+        self,
+        client: AsyncClient,
+    ):
+        """Unauthenticated request should return 401."""
+        response = await client.get(
+            "/api/v1/meal-plans",
+            params={"week_start": "2025-01-06"},
+        )
+
+        assert response.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_get_meal_plan_other_user_returns_403(
+        self,
+        client: AsyncClient,
+        auth_headers: dict,
+        auth_headers_user2: dict,
+        test_user,
+        test_user2,
+    ):
+        """User should not access another user's meal plan (403)."""
+        # User 1 creates a plan
+        response = await client.get(
+            "/api/v1/meal-plans",
+            headers=auth_headers,
+            params={"week_start": "2025-01-06"},
+        )
+        assert response.status_code == 200
+
+        # User 2 requests the same week - should get their own plan, not user 1's
+        # This test verifies ownership isolation: each user gets their own plan
+        response2 = await client.get(
+            "/api/v1/meal-plans",
+            headers=auth_headers_user2,
+            params={"week_start": "2025-01-06"},
+        )
+        assert response2.status_code == 200
+        # Plans should be different (different owners)
+        assert response2.json()["id"] != response.json()["id"]
+
+    @pytest.mark.asyncio
+    async def test_get_meal_plan_entry_with_null_recipe_id(
+        self,
+        client: AsyncClient,
+        auth_headers: dict,
+        test_user,
+        test_db: AsyncSession,
+    ):
+        """Entry with null recipe_id (deleted recipe) should return gracefully."""
+        # Auto-create a plan
+        response = await client.get(
+            "/api/v1/meal-plans",
+            headers=auth_headers,
+            params={"week_start": "2025-01-06"},
+        )
+        assert response.status_code == 200
+        plan_id = response.json()["id"]
+
+        # Manually insert an entry with null recipe_id to simulate deleted recipe
+        from app.models.meal_plan import MealPlanEntry
+
+        entry = MealPlanEntry(
+            meal_plan_id=plan_id,
+            day_of_week=0,  # Monday
+            meal_type="dinner",
+            recipe_id=None,
+        )
+        test_db.add(entry)
+        await test_db.commit()
+
+        # GET should still work and include the entry with null recipe details
+        response = await client.get(
+            "/api/v1/meal-plans",
+            headers=auth_headers,
+            params={"week_start": "2025-01-06"},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data["entries"]) == 1
+        assert data["entries"][0]["recipe"] is None
+
+    @pytest.mark.asyncio
+    async def test_get_meal_plan_entries_include_recipe_details(
+        self,
+        client: AsyncClient,
+        auth_headers: dict,
+        test_user,
+        test_recipe,
+        test_db: AsyncSession,
+    ):
+        """Entries should include recipe name and cook time from linked recipe."""
+        # Auto-create a plan
+        response = await client.get(
+            "/api/v1/meal-plans",
+            headers=auth_headers,
+            params={"week_start": "2025-01-06"},
+        )
+        assert response.status_code == 200
+        plan_id = response.json()["id"]
+
+        # Manually insert an entry linked to test_recipe
+        from app.models.meal_plan import MealPlanEntry
+
+        entry = MealPlanEntry(
+            meal_plan_id=plan_id,
+            day_of_week=2,  # Wednesday
+            meal_type="lunch",
+            recipe_id=test_recipe.id,
+        )
+        test_db.add(entry)
+        await test_db.commit()
+
+        # GET should include recipe details
+        response = await client.get(
+            "/api/v1/meal-plans",
+            headers=auth_headers,
+            params={"week_start": "2025-01-06"},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data["entries"]) == 1
+        entry_data = data["entries"][0]
+        assert entry_data["recipe"]["id"] == test_recipe.id
+        assert entry_data["recipe"]["title"] == "Test Recipe"
+        assert entry_data["recipe"]["cook_time_minutes"] == 30
+
+
+class TestUpsertMealPlanEntry:
+    """Tests for PUT /api/v1/meal-plans/{plan_id}/entries — assign recipe to meal slot."""
+
+    async def _create_plan(
+        self, client: AsyncClient, auth_headers: dict, week_start: str = "2025-01-06"
+    ) -> dict:
+        """Helper: auto-create a plan and return its JSON."""
+        resp = await client.get(
+            "/api/v1/meal-plans",
+            headers=auth_headers,
+            params={"week_start": week_start},
+        )
+        assert resp.status_code == 200
+        return resp.json()
+
+    @pytest.mark.asyncio
+    async def test_upsert_entry_creates_new_entry(
+        self,
+        client: AsyncClient,
+        auth_headers: dict,
+        test_user,
+        test_recipe,
+    ):
+        """PUT with valid data should create a new entry and return it."""
+        plan = await self._create_plan(client, auth_headers)
+
+        response = await client.put(
+            f"/api/v1/meal-plans/{plan['id']}/entries",
+            headers=auth_headers,
+            json={
+                "date": "2025-01-07",  # Tuesday within the week
+                "meal_type": "dinner",
+                "recipe_id": test_recipe.id,
+            },
+        )
+
+        assert response.status_code in (200, 201)
+        data = response.json()
+        assert data["meal_type"] == "dinner"
+        assert data["recipe"]["id"] == test_recipe.id
+        assert "id" in data
+
+    @pytest.mark.asyncio
+    async def test_upsert_entry_updates_existing_slot(
+        self,
+        client: AsyncClient,
+        auth_headers: dict,
+        test_user,
+        test_recipe,
+        test_db: AsyncSession,
+    ):
+        """PUT with same date+meal_type should update the existing entry, not duplicate."""
+        plan = await self._create_plan(client, auth_headers)
+        entry_payload = {
+            "date": "2025-01-07",
+            "meal_type": "lunch",
+            "recipe_id": test_recipe.id,
+        }
+
+        # First upsert
+        resp1 = await client.put(
+            f"/api/v1/meal-plans/{plan['id']}/entries",
+            headers=auth_headers,
+            json=entry_payload,
+        )
+        assert resp1.status_code in (200, 201)
+        entry_id_1 = resp1.json()["id"]
+
+        # Create a second recipe to swap in (use the same recipe for simplicity;
+        # the key point is that the entry is updated, not duplicated)
+        resp2 = await client.put(
+            f"/api/v1/meal-plans/{plan['id']}/entries",
+            headers=auth_headers,
+            json=entry_payload,
+        )
+        assert resp2.status_code in (200, 201)
+        entry_id_2 = resp2.json()["id"]
+
+        # Same slot should reuse the same entry
+        assert entry_id_1 == entry_id_2
+
+        # Verify only one entry exists for that slot
+        plan_resp = await client.get(
+            "/api/v1/meal-plans",
+            headers=auth_headers,
+            params={"week_start": "2025-01-06"},
+        )
+        entries = plan_resp.json()["entries"]
+        lunch_entries = [e for e in entries if e["meal_type"] == "lunch"]
+        assert len(lunch_entries) == 1
+
+    @pytest.mark.asyncio
+    async def test_upsert_entry_invalid_meal_type_returns_422(
+        self,
+        client: AsyncClient,
+        auth_headers: dict,
+        test_user,
+        test_recipe,
+    ):
+        """PUT with invalid meal_type should return 422."""
+        plan = await self._create_plan(client, auth_headers)
+
+        response = await client.put(
+            f"/api/v1/meal-plans/{plan['id']}/entries",
+            headers=auth_headers,
+            json={
+                "date": "2025-01-07",
+                "meal_type": "midnight_snack",  # invalid
+                "recipe_id": test_recipe.id,
+            },
+        )
+
+        assert response.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_upsert_entry_date_outside_plan_week_returns_422(
+        self,
+        client: AsyncClient,
+        auth_headers: dict,
+        test_user,
+        test_recipe,
+    ):
+        """PUT with a date outside the plan's week should return 422."""
+        plan = await self._create_plan(client, auth_headers, week_start="2025-01-06")
+
+        response = await client.put(
+            f"/api/v1/meal-plans/{plan['id']}/entries",
+            headers=auth_headers,
+            json={
+                "date": "2025-01-20",  # Two weeks later
+                "meal_type": "dinner",
+                "recipe_id": test_recipe.id,
+            },
+        )
+
+        assert response.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_upsert_entry_nonexistent_recipe_returns_error(
+        self,
+        client: AsyncClient,
+        auth_headers: dict,
+        test_user,
+    ):
+        """PUT with a recipe_id that doesn't exist should return 404 or 422."""
+        plan = await self._create_plan(client, auth_headers)
+
+        response = await client.put(
+            f"/api/v1/meal-plans/{plan['id']}/entries",
+            headers=auth_headers,
+            json={
+                "date": "2025-01-07",
+                "meal_type": "dinner",
+                "recipe_id": "nonexistent-recipe-id",
+            },
+        )
+
+        assert response.status_code in (404, 422)
+
+    @pytest.mark.asyncio
+    async def test_upsert_entry_nonexistent_plan_returns_404(
+        self,
+        client: AsyncClient,
+        auth_headers: dict,
+        test_user,
+        test_recipe,
+    ):
+        """PUT on a nonexistent plan_id should return 404."""
+        response = await client.put(
+            "/api/v1/meal-plans/nonexistent-plan-id/entries",
+            headers=auth_headers,
+            json={
+                "date": "2025-01-07",
+                "meal_type": "dinner",
+                "recipe_id": test_recipe.id,
+            },
+        )
+
+        assert response.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_upsert_entry_other_users_plan_returns_403(
+        self,
+        client: AsyncClient,
+        auth_headers: dict,
+        auth_headers_user2: dict,
+        test_user,
+        test_user2,
+        test_recipe,
+    ):
+        """PUT on another user's plan should return 403."""
+        # User 1 creates a plan
+        plan = await self._create_plan(client, auth_headers)
+
+        # User 2 tries to add an entry to User 1's plan
+        response = await client.put(
+            f"/api/v1/meal-plans/{plan['id']}/entries",
+            headers=auth_headers_user2,
+            json={
+                "date": "2025-01-07",
+                "meal_type": "dinner",
+                "recipe_id": test_recipe.id,
+            },
+        )
+
+        assert response.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_upsert_entry_unauthenticated_returns_401(
+        self,
+        client: AsyncClient,
+    ):
+        """PUT without auth should return 401."""
+        response = await client.put(
+            "/api/v1/meal-plans/some-plan-id/entries",
+            json={
+                "date": "2025-01-07",
+                "meal_type": "dinner",
+                "recipe_id": "some-recipe-id",
+            },
+        )
+
+        assert response.status_code == 401
+
+
+class TestDeleteMealPlanEntry:
+    """Tests for DELETE /api/v1/meal-plans/{plan_id}/entries/{entry_id}."""
+
+    async def _create_plan_with_entry(
+        self,
+        client: AsyncClient,
+        auth_headers: dict,
+        test_recipe,
+    ) -> tuple[str, str]:
+        """Helper: create a plan and add an entry, return (plan_id, entry_id)."""
+        # Create plan
+        resp = await client.get(
+            "/api/v1/meal-plans",
+            headers=auth_headers,
+            params={"week_start": "2025-01-06"},
+        )
+        plan_id = resp.json()["id"]
+
+        # Add entry via upsert
+        entry_resp = await client.put(
+            f"/api/v1/meal-plans/{plan_id}/entries",
+            headers=auth_headers,
+            json={
+                "date": "2025-01-07",
+                "meal_type": "dinner",
+                "recipe_id": test_recipe.id,
+            },
+        )
+        entry_id = entry_resp.json()["id"]
+        return plan_id, entry_id
+
+    @pytest.mark.asyncio
+    async def test_delete_entry_returns_204(
+        self,
+        client: AsyncClient,
+        auth_headers: dict,
+        test_user,
+        test_recipe,
+    ):
+        """DELETE existing entry should return 204 and remove it."""
+        plan_id, entry_id = await self._create_plan_with_entry(
+            client, auth_headers, test_recipe
+        )
+
+        response = await client.delete(
+            f"/api/v1/meal-plans/{plan_id}/entries/{entry_id}",
+            headers=auth_headers,
+        )
+
+        assert response.status_code == 204
+
+        # Verify entry is gone
+        plan_resp = await client.get(
+            "/api/v1/meal-plans",
+            headers=auth_headers,
+            params={"week_start": "2025-01-06"},
+        )
+        assert len(plan_resp.json()["entries"]) == 0
+
+    @pytest.mark.asyncio
+    async def test_delete_nonexistent_entry_returns_404(
+        self,
+        client: AsyncClient,
+        auth_headers: dict,
+        test_user,
+    ):
+        """DELETE a nonexistent entry should return 404."""
+        # Create a plan so plan_id is valid
+        resp = await client.get(
+            "/api/v1/meal-plans",
+            headers=auth_headers,
+            params={"week_start": "2025-01-06"},
+        )
+        plan_id = resp.json()["id"]
+
+        response = await client.delete(
+            f"/api/v1/meal-plans/{plan_id}/entries/nonexistent-entry-id",
+            headers=auth_headers,
+        )
+
+        assert response.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_delete_entry_other_users_plan_returns_403(
+        self,
+        client: AsyncClient,
+        auth_headers: dict,
+        auth_headers_user2: dict,
+        test_user,
+        test_user2,
+        test_recipe,
+    ):
+        """DELETE on another user's plan entry should return 403."""
+        plan_id, entry_id = await self._create_plan_with_entry(
+            client, auth_headers, test_recipe
+        )
+
+        response = await client.delete(
+            f"/api/v1/meal-plans/{plan_id}/entries/{entry_id}",
+            headers=auth_headers_user2,
+        )
+
+        assert response.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_delete_entry_unauthenticated_returns_401(
+        self,
+        client: AsyncClient,
+    ):
+        """DELETE without auth should return 401."""
+        response = await client.delete(
+            "/api/v1/meal-plans/some-plan-id/entries/some-entry-id",
+        )
+
+        assert response.status_code == 401

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -242,7 +242,10 @@ e2e/
 │   │   ├── recipe-crud.spec.ts
 │   │   ├── settings.spec.ts
 │   │   ├── sharing.spec.ts
-│   │   └── workflows.spec.ts
+│   │   ├── workflows.spec.ts
+│   │   ├── meal-plan.spec.ts
+│   │   ├── meal-plan-recipes.spec.ts
+│   │   └── meal-plan-week-nav.spec.ts
 │   └── comprehensive/               # Edge cases & non-critical paths
 │       ├── chat-edge-cases.spec.ts
 │       ├── error-handling.spec.ts
@@ -255,7 +258,8 @@ e2e/
 │   ├── register.page.ts
 │   ├── recipes.page.ts
 │   ├── create-recipe.page.ts
-│   └── recipe-detail.page.ts
+│   ├── recipe-detail.page.ts
+│   └── meal-plan.page.ts
 ├── fixtures/                        # Test fixtures
 │   └── auth.fixture.ts
 ├── utils/                           # Test utilities

--- a/e2e/CLAUDE.md
+++ b/e2e/CLAUDE.md
@@ -12,7 +12,8 @@ e2e/
 ├── fixtures/
 │   └── auth.fixture.ts       # Authenticated page fixture
 ├── pages/
-│   └── *.page.ts             # Page objects
+│   ├── *.page.ts             # Page objects
+│   └── meal-plan.page.ts
 ├── utils/
 │   ├── api.ts                # APIHelper for direct API calls
 │   └── test-data.ts          # Test data generators
@@ -28,7 +29,10 @@ e2e/
 │   │   ├── recipe-crud.spec.ts
 │   │   ├── settings.spec.ts
 │   │   ├── sharing.spec.ts
-│   │   └── workflows.spec.ts
+│   │   ├── workflows.spec.ts
+│   │   ├── meal-plan.spec.ts
+│   │   ├── meal-plan-recipes.spec.ts
+│   │   └── meal-plan-week-nav.spec.ts
 │   └── comprehensive/        # Edge cases, error handling, responsive
 │       ├── chat-edge-cases.spec.ts
 │       ├── error-handling.spec.ts

--- a/e2e/pages/meal-plan.page.ts
+++ b/e2e/pages/meal-plan.page.ts
@@ -1,0 +1,84 @@
+import { Page, Locator } from '@playwright/test';
+import { BasePage } from './base.page';
+
+export class MealPlanPage extends BasePage {
+  readonly calendarGrid: Locator;
+  readonly dayColumns: Locator;
+  readonly todayColumn: Locator;
+
+  // Week navigation locators
+  readonly prevWeekButton: Locator;
+  readonly nextWeekButton: Locator;
+  readonly todayButton: Locator;
+  readonly dateRangeLabel: Locator;
+
+  // Recipe picker modal locators
+  readonly recipePickerModal: Locator;
+  readonly recipePickerSearchInput: Locator;
+  readonly recipePickerList: Locator;
+  readonly recipePickerItems: Locator;
+
+  constructor(page: Page) {
+    super(page);
+    this.calendarGrid = page.getByTestId('meal-plan-calendar');
+    this.dayColumns = page.getByTestId('day-column');
+    this.todayColumn = page.getByTestId('day-column-today');
+
+    // Week navigation
+    this.prevWeekButton = page.getByRole('button', { name: /previous week/i });
+    this.nextWeekButton = page.getByRole('button', { name: /next week/i });
+    this.todayButton = page.getByRole('button', { name: /today/i });
+    this.dateRangeLabel = page.getByTestId('week-date-range');
+
+    // Recipe picker modal
+    this.recipePickerModal = page.getByTestId('recipe-picker-modal');
+    this.recipePickerSearchInput = this.recipePickerModal.getByRole('textbox', { name: /search/i });
+    this.recipePickerList = this.recipePickerModal.getByTestId('recipe-picker-list');
+    this.recipePickerItems = this.recipePickerList.getByTestId('recipe-picker-item');
+  }
+
+  async goto() {
+    await super.goto('/planning');
+  }
+
+  getDayColumn(dayName: string): Locator {
+    return this.calendarGrid.locator(`[data-testid="day-column"]`, {
+      has: this.page.getByText(dayName, { exact: false }),
+    });
+  }
+
+  getMealSlots(dayName: string): Locator {
+    return this.getDayColumn(dayName).getByTestId('meal-slot');
+  }
+
+  getAddButton(dayName: string, meal: 'Breakfast' | 'Lunch' | 'Dinner'): Locator {
+    return this.getDayColumn(dayName)
+      .locator('[data-testid="meal-slot"]', {
+        has: this.page.getByText(meal),
+      })
+      .getByText(/\+\s*Add/i);
+  }
+
+  getMealSlot(dayName: string, meal: 'Breakfast' | 'Lunch' | 'Dinner'): Locator {
+    return this.getDayColumn(dayName)
+      .locator('[data-testid="meal-slot"]', {
+        has: this.page.getByText(meal),
+      });
+  }
+
+  getFilledSlotRecipeName(dayName: string, meal: 'Breakfast' | 'Lunch' | 'Dinner'): Locator {
+    return this.getMealSlot(dayName, meal).getByTestId('slot-recipe-name');
+  }
+
+  getRecipePickerItem(recipeName: string): Locator {
+    return this.recipePickerItems.filter({ hasText: recipeName });
+  }
+
+  getRemoveButton(dayName: string, meal: 'Breakfast' | 'Lunch' | 'Dinner'): Locator {
+    return this.getMealSlot(dayName, meal).getByRole('button', { name: /remove/i });
+  }
+
+  getChangeButton(dayName: string, meal: 'Breakfast' | 'Lunch' | 'Dinner'): Locator {
+    return this.getMealSlot(dayName, meal).getByRole('button', { name: /change/i });
+  }
+}

--- a/e2e/tests/core/meal-plan-recipes.spec.ts
+++ b/e2e/tests/core/meal-plan-recipes.spec.ts
@@ -1,0 +1,155 @@
+/**
+ * Core Tier: Assign and Remove Recipes from Meal Slots
+ *
+ * Covers: recipe picker modal, search filtering, assigning recipes
+ * to slots, changing assigned recipes, removing recipes from slots
+ */
+
+import { test, expect } from '../../fixtures/auth.fixture';
+import { MealPlanPage } from '../../pages/meal-plan.page';
+import { APIHelper } from '../../utils/api';
+import { generateRecipeData } from '../../utils/test-data';
+
+const FIRST_DAY = 'Mon';
+
+test.describe('Core: Assign and Remove Recipes from Meal Slots', () => {
+  let token: string;
+  let recipeName: string;
+
+  test.beforeEach(async ({ authenticatedPage, request }) => {
+    const api = new APIHelper(request);
+    token = await authenticatedPage.evaluate(() =>
+      localStorage.getItem('auth_token')
+    ) as string;
+
+    // Create a recipe via API so the picker has something to show
+    const recipeData = generateRecipeData({ title: `Pancakes ${Date.now()}` });
+    recipeName = recipeData.title;
+    await api.createRecipe(token, recipeData);
+  });
+
+  test('user clicks empty slot and sees recipe picker modal', async ({
+    authenticatedPage,
+  }) => {
+    const mealPlan = new MealPlanPage(authenticatedPage);
+    await mealPlan.goto();
+
+    // Click the "+ Add" button on Monday Breakfast
+    await mealPlan.getAddButton(FIRST_DAY, 'Breakfast').click();
+
+    // Recipe picker modal should appear
+    await expect(mealPlan.recipePickerModal).toBeVisible();
+    await expect(mealPlan.recipePickerSearchInput).toBeVisible();
+    await expect(mealPlan.recipePickerItems).toHaveCount(1, { timeout: 5000 });
+  });
+
+  test('user searches and filters the recipe list in the picker', async ({
+    authenticatedPage,
+    request,
+  }) => {
+    const api = new APIHelper(request);
+    // Create a second recipe with a different name
+    const secondRecipe = generateRecipeData({ title: `Spaghetti ${Date.now()}` });
+    await api.createRecipe(token, secondRecipe);
+
+    const mealPlan = new MealPlanPage(authenticatedPage);
+    await mealPlan.goto();
+
+    await mealPlan.getAddButton(FIRST_DAY, 'Breakfast').click();
+    await expect(mealPlan.recipePickerModal).toBeVisible();
+
+    // Both recipes should be listed initially
+    await expect(mealPlan.recipePickerItems).toHaveCount(2, { timeout: 5000 });
+
+    // Type a search term that matches only one recipe
+    await mealPlan.recipePickerSearchInput.fill('Pancakes');
+
+    // Only the matching recipe should remain
+    await expect(mealPlan.recipePickerItems).toHaveCount(1);
+    await expect(mealPlan.getRecipePickerItem('Pancakes')).toBeVisible();
+  });
+
+  test('user selects a recipe and the slot shows the recipe name', async ({
+    authenticatedPage,
+  }) => {
+    const mealPlan = new MealPlanPage(authenticatedPage);
+    await mealPlan.goto();
+
+    // Open picker for Monday Breakfast
+    await mealPlan.getAddButton(FIRST_DAY, 'Breakfast').click();
+    await expect(mealPlan.recipePickerModal).toBeVisible();
+
+    // Select the recipe
+    await mealPlan.getRecipePickerItem(recipeName).click();
+
+    // Modal should close
+    await expect(mealPlan.recipePickerModal).toBeHidden();
+
+    // Slot should now display the recipe name
+    await expect(
+      mealPlan.getFilledSlotRecipeName(FIRST_DAY, 'Breakfast')
+    ).toHaveText(recipeName);
+
+    // The "+ Add" button should no longer be visible for this slot
+    await expect(mealPlan.getAddButton(FIRST_DAY, 'Breakfast')).toBeHidden();
+  });
+
+  test('user clicks a filled slot and can change the recipe', async ({
+    authenticatedPage,
+    request,
+  }) => {
+    const api = new APIHelper(request);
+    const secondRecipe = generateRecipeData({ title: `Waffles ${Date.now()}` });
+    const secondName = secondRecipe.title;
+    await api.createRecipe(token, secondRecipe);
+
+    const mealPlan = new MealPlanPage(authenticatedPage);
+    await mealPlan.goto();
+
+    // Assign first recipe to Monday Breakfast
+    await mealPlan.getAddButton(FIRST_DAY, 'Breakfast').click();
+    await expect(mealPlan.recipePickerModal).toBeVisible();
+    await mealPlan.getRecipePickerItem(recipeName).click();
+    await expect(mealPlan.recipePickerModal).toBeHidden();
+
+    // Click the filled slot to change recipe
+    await mealPlan.getChangeButton(FIRST_DAY, 'Breakfast').click();
+    await expect(mealPlan.recipePickerModal).toBeVisible();
+
+    // Select the second recipe
+    await mealPlan.getRecipePickerItem(secondName).click();
+    await expect(mealPlan.recipePickerModal).toBeHidden();
+
+    // Slot should now show the second recipe
+    await expect(
+      mealPlan.getFilledSlotRecipeName(FIRST_DAY, 'Breakfast')
+    ).toHaveText(secondName);
+  });
+
+  test('user removes a recipe and the slot returns to empty state', async ({
+    authenticatedPage,
+  }) => {
+    const mealPlan = new MealPlanPage(authenticatedPage);
+    await mealPlan.goto();
+
+    // Assign recipe to Monday Breakfast
+    await mealPlan.getAddButton(FIRST_DAY, 'Breakfast').click();
+    await expect(mealPlan.recipePickerModal).toBeVisible();
+    await mealPlan.getRecipePickerItem(recipeName).click();
+    await expect(mealPlan.recipePickerModal).toBeHidden();
+
+    // Verify recipe is assigned
+    await expect(
+      mealPlan.getFilledSlotRecipeName(FIRST_DAY, 'Breakfast')
+    ).toHaveText(recipeName);
+
+    // Remove the recipe
+    await mealPlan.getRemoveButton(FIRST_DAY, 'Breakfast').click();
+
+    // Slot should return to empty state with "+ Add" button
+    await expect(mealPlan.getAddButton(FIRST_DAY, 'Breakfast')).toBeVisible();
+    await expect(
+      mealPlan.getFilledSlotRecipeName(FIRST_DAY, 'Breakfast')
+    ).toBeHidden();
+  });
+});

--- a/e2e/tests/core/meal-plan-week-nav.spec.ts
+++ b/e2e/tests/core/meal-plan-week-nav.spec.ts
@@ -1,0 +1,134 @@
+/**
+ * Core Tier: Navigate Between Weeks
+ *
+ * Covers: previous/next week arrows, Today button,
+ * date range label format, data loading per week
+ */
+
+import { test, expect } from '../../fixtures/auth.fixture';
+import { MealPlanPage } from '../../pages/meal-plan.page';
+
+/**
+ * Returns the Monday and Sunday of the week containing the given date,
+ * formatted as "Mon DD - Sun DD" (e.g. "Jan 27 - Feb 02").
+ */
+function expectedDateRange(referenceDate: Date): string {
+  const d = new Date(referenceDate);
+  const dayOfWeek = d.getDay(); // 0=Sun, 1=Mon, ...
+  const diffToMon = dayOfWeek === 0 ? -6 : 1 - dayOfWeek;
+  const monday = new Date(d);
+  monday.setDate(d.getDate() + diffToMon);
+  const sunday = new Date(monday);
+  sunday.setDate(monday.getDate() + 6);
+
+  const fmt = (date: Date) => {
+    const mon = date.toLocaleDateString('en-US', { month: 'short' });
+    const day = String(date.getDate()).padStart(2, '0');
+    return `${mon} ${day}`;
+  };
+
+  return `${fmt(monday)} - ${fmt(sunday)}`;
+}
+
+function offsetWeek(weeks: number): Date {
+  const d = new Date();
+  d.setDate(d.getDate() + weeks * 7);
+  return d;
+}
+
+test.describe('Core: Navigate Between Weeks', () => {
+  test('user sees week navigation controls on the meal plan page', async ({
+    authenticatedPage,
+  }) => {
+    const mealPlan = new MealPlanPage(authenticatedPage);
+    await mealPlan.goto();
+
+    await expect(mealPlan.prevWeekButton).toBeVisible();
+    await expect(mealPlan.nextWeekButton).toBeVisible();
+    await expect(mealPlan.todayButton).toBeVisible();
+    await expect(mealPlan.dateRangeLabel).toBeVisible();
+  });
+
+  test('date range label shows current week in "Mon DD - Sun DD" format', async ({
+    authenticatedPage,
+  }) => {
+    const mealPlan = new MealPlanPage(authenticatedPage);
+    await mealPlan.goto();
+
+    const expected = expectedDateRange(new Date());
+    await expect(mealPlan.dateRangeLabel).toHaveText(expected);
+  });
+
+  test('user clicks next arrow and sees the following week dates', async ({
+    authenticatedPage,
+  }) => {
+    const mealPlan = new MealPlanPage(authenticatedPage);
+    await mealPlan.goto();
+
+    await mealPlan.nextWeekButton.click();
+
+    const expected = expectedDateRange(offsetWeek(1));
+    await expect(mealPlan.dateRangeLabel).toHaveText(expected);
+  });
+
+  test('user clicks prev arrow and sees the previous week dates', async ({
+    authenticatedPage,
+  }) => {
+    const mealPlan = new MealPlanPage(authenticatedPage);
+    await mealPlan.goto();
+
+    await mealPlan.prevWeekButton.click();
+
+    const expected = expectedDateRange(offsetWeek(-1));
+    await expect(mealPlan.dateRangeLabel).toHaveText(expected);
+  });
+
+  test('user navigates away and clicks Today to return to current week', async ({
+    authenticatedPage,
+  }) => {
+    const mealPlan = new MealPlanPage(authenticatedPage);
+    await mealPlan.goto();
+
+    // Navigate two weeks forward
+    await mealPlan.nextWeekButton.click();
+    await mealPlan.nextWeekButton.click();
+
+    const futureRange = expectedDateRange(offsetWeek(2));
+    await expect(mealPlan.dateRangeLabel).toHaveText(futureRange);
+
+    // Click Today to return
+    await mealPlan.todayButton.click();
+
+    const currentRange = expectedDateRange(new Date());
+    await expect(mealPlan.dateRangeLabel).toHaveText(currentRange);
+  });
+
+  test('today column highlight is absent when viewing a non-current week', async ({
+    authenticatedPage,
+  }) => {
+    const mealPlan = new MealPlanPage(authenticatedPage);
+    await mealPlan.goto();
+
+    // Confirm today column exists for current week
+    await expect(mealPlan.todayColumn).toBeVisible();
+
+    // Navigate to next week
+    await mealPlan.nextWeekButton.click();
+
+    // Today highlight should not appear on a different week
+    await expect(mealPlan.todayColumn).toBeHidden();
+  });
+
+  test('meal plan data loads for the navigated week', async ({
+    authenticatedPage,
+  }) => {
+    const mealPlan = new MealPlanPage(authenticatedPage);
+    await mealPlan.goto();
+
+    // Navigate to next week and verify the grid still renders 7 days
+    await mealPlan.nextWeekButton.click();
+
+    await expect(mealPlan.calendarGrid).toBeVisible();
+    await expect(mealPlan.dayColumns).toHaveCount(7);
+  });
+});

--- a/e2e/tests/core/meal-plan.spec.ts
+++ b/e2e/tests/core/meal-plan.spec.ts
@@ -1,0 +1,68 @@
+/**
+ * Core Tier: Meal Plan Page
+ *
+ * Covers: 7-day calendar grid display, meal slot labels,
+ * today highlight, empty slot placeholders
+ */
+
+import { test, expect } from '../../fixtures/auth.fixture';
+import { MealPlanPage } from '../../pages/meal-plan.page';
+
+const WEEKDAYS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
+
+test.describe('Core: Meal Plan Calendar Grid', () => {
+  test('user sees a 7-day calendar grid when navigating to /planning', async ({
+    authenticatedPage,
+  }) => {
+    const mealPlan = new MealPlanPage(authenticatedPage);
+    await mealPlan.goto();
+
+    await expect(mealPlan.calendarGrid).toBeVisible();
+    await expect(mealPlan.dayColumns).toHaveCount(7);
+
+    for (const day of WEEKDAYS) {
+      await expect(mealPlan.getDayColumn(day)).toBeVisible();
+    }
+  });
+
+  test('each day shows Breakfast, Lunch, and Dinner meal slots', async ({
+    authenticatedPage,
+  }) => {
+    const mealPlan = new MealPlanPage(authenticatedPage);
+    await mealPlan.goto();
+
+    for (const day of WEEKDAYS) {
+      await expect(mealPlan.getMealSlots(day)).toHaveCount(3);
+
+      for (const meal of ['Breakfast', 'Lunch', 'Dinner'] as const) {
+        await expect(
+          mealPlan.getDayColumn(day).getByText(meal)
+        ).toBeVisible();
+      }
+    }
+  });
+
+  test('today column is visually distinct from other days', async ({
+    authenticatedPage,
+  }) => {
+    const mealPlan = new MealPlanPage(authenticatedPage);
+    await mealPlan.goto();
+
+    // Exactly one column should be marked as today
+    await expect(mealPlan.todayColumn).toBeVisible();
+    await expect(mealPlan.todayColumn).toHaveCount(1);
+  });
+
+  test('empty meal slots show "+ Add" placeholder text', async ({
+    authenticatedPage,
+  }) => {
+    const mealPlan = new MealPlanPage(authenticatedPage);
+    await mealPlan.goto();
+
+    // Check the first day has add placeholders in all three slots
+    const firstDay = WEEKDAYS[0];
+    for (const meal of ['Breakfast', 'Lunch', 'Dinner'] as const) {
+      await expect(mealPlan.getAddButton(firstDay, meal)).toBeVisible();
+    }
+  });
+});

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -23,6 +23,7 @@ import LibrariesPage from './pages/LibrariesPage';
 import LibraryDetailPage from './pages/LibraryDetailPage';
 import SharedRecipePage from './pages/SharedRecipePage';
 import SettingsPage from './pages/SettingsPage';
+import MealPlanPage from './pages/MealPlanPage';
 
 function App() {
   return (
@@ -47,7 +48,7 @@ function App() {
                 <Route path="/libraries" element={<LibrariesPage />} />
                 <Route path="/libraries/:id" element={<LibraryDetailPage />} />
                 <Route path="/discover" element={<ComingSoonPage title="Discover" />} />
-                <Route path="/planning" element={<ComingSoonPage title="Meal Planning" />} />
+                <Route path="/planning" element={<MealPlanPage />} />
                 <Route path="/shopping" element={<ComingSoonPage title="Shopping List" />} />
                 <Route path="/cooking" element={<ComingSoonPage title="Cooking Mode" />} />
                 <Route path="/settings" element={<SettingsPage />} />

--- a/frontend/src/components/meal-plan/DayColumn.test.tsx
+++ b/frontend/src/components/meal-plan/DayColumn.test.tsx
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '../../test/test-utils';
+import { DayColumn } from './DayColumn';
+import { mockMealPlanEntry } from '../../test/mocks/mealPlanData';
+
+describe('DayColumn', () => {
+  it('should render the day name as a header', () => {
+    render(<DayColumn dayName="Monday" date="2026-01-26" entries={[]} isToday={false} />);
+
+    expect(screen.getByRole('heading', { name: 'Monday' })).toBeInTheDocument();
+  });
+
+  it('should render 3 meal slots (Breakfast, Lunch, Dinner)', () => {
+    render(<DayColumn dayName="Tuesday" date="2026-01-27" entries={[]} isToday={false} />);
+
+    expect(screen.getByText('Breakfast')).toBeInTheDocument();
+    expect(screen.getByText('Lunch')).toBeInTheDocument();
+    expect(screen.getByText('Dinner')).toBeInTheDocument();
+  });
+
+  it('should apply accent styling when isToday is true', () => {
+    const { container } = render(
+      <DayColumn dayName="Wednesday" date="2026-01-28" entries={[]} isToday={true} />
+    );
+
+    const column = container.firstElementChild;
+    expect(column?.className).toMatch(/accent|today|highlight/);
+  });
+
+  it('should pass entries to the correct meal slots', () => {
+    const entries = [
+      mockMealPlanEntry({
+        meal_type: 'breakfast',
+        recipe: { id: 'r1', title: 'Pancakes', cook_time_minutes: 15 },
+      }),
+      mockMealPlanEntry({
+        meal_type: 'dinner',
+        recipe: { id: 'r2', title: 'Pasta', cook_time_minutes: 25 },
+      }),
+    ];
+
+    render(<DayColumn dayName="Thursday" date="2026-01-29" entries={entries} isToday={false} />);
+
+    expect(screen.getByText('Pancakes')).toBeInTheDocument();
+    expect(screen.getByText('Pasta')).toBeInTheDocument();
+    // Lunch should be empty
+    expect(screen.getByText(/\+ Add/)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/meal-plan/DayColumn.tsx
+++ b/frontend/src/components/meal-plan/DayColumn.tsx
@@ -1,0 +1,69 @@
+import { MealSlot } from './MealSlot';
+import type { MealType } from '../../types/mealPlan';
+
+interface DayColumnEntry {
+  id: string;
+  meal_type: MealType;
+  recipe: { id: string; title: string; cook_time_minutes: number } | null;
+}
+
+interface DayColumnProps {
+  dayName: string;
+  date: string;
+  entries: DayColumnEntry[];
+  isToday: boolean;
+  onSlotClick?: (mealType: MealType) => void;
+  onRemoveClick?: (entryId: string, mealType: MealType) => void;
+}
+
+const MEAL_TYPES: MealType[] = ['breakfast', 'lunch', 'dinner'];
+
+export function DayColumn({
+  dayName,
+  entries,
+  isToday,
+  onSlotClick,
+  onRemoveClick,
+}: DayColumnProps) {
+  const findEntry = (mealType: MealType) => {
+    const e = entries.find((entry) => entry.meal_type === mealType);
+    if (!e) return null;
+    return {
+      id: e.id,
+      recipe: e.recipe
+        ? { id: e.recipe.id, title: e.recipe.title, cookTimeMinutes: e.recipe.cook_time_minutes }
+        : null,
+    };
+  };
+
+  return (
+    <div
+      className={`flex flex-col gap-2 ${isToday ? 'border-accent border-2 rounded-lg p-2' : 'p-2'}`}
+      data-testid="day-column"
+    >
+      <h3 className="text-text-primary font-semibold text-center">
+        {dayName}
+        {isToday && (
+          <span data-testid="day-column-today" className="ml-1 text-accent text-xs">
+            (Today)
+          </span>
+        )}
+      </h3>
+      {MEAL_TYPES.map((mt) => {
+        const entry = findEntry(mt);
+        return (
+          <MealSlot
+            key={mt}
+            mealType={mt}
+            entry={entry}
+            onAddClick={() => onSlotClick?.(mt)}
+            onChangeClick={() => onSlotClick?.(mt)}
+            onRemoveClick={() => {
+              if (entry) onRemoveClick?.(entry.id, mt);
+            }}
+          />
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/src/components/meal-plan/MealSlot.test.tsx
+++ b/frontend/src/components/meal-plan/MealSlot.test.tsx
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '../../test/test-utils';
+import { MealSlot } from './MealSlot';
+
+describe('MealSlot', () => {
+  it('should render empty state with "+ Add" and meal type label', () => {
+    render(<MealSlot mealType="breakfast" entry={null} />);
+
+    expect(screen.getByText('Breakfast')).toBeInTheDocument();
+    expect(screen.getByText(/\+ Add/)).toBeInTheDocument();
+  });
+
+  it('should render recipe name and cook time for filled entry', () => {
+    render(
+      <MealSlot
+        mealType="lunch"
+        entry={{
+          id: 'e1',
+          recipe: { id: 'r1', title: 'Caesar Salad', cookTimeMinutes: 15 },
+        }}
+      />
+    );
+
+    expect(screen.getByText('Lunch')).toBeInTheDocument();
+    expect(screen.getByText('Caesar Salad')).toBeInTheDocument();
+    expect(screen.getByText(/15 min/)).toBeInTheDocument();
+  });
+
+  it('should render "Recipe removed" when entry has null recipe', () => {
+    render(
+      <MealSlot
+        mealType="dinner"
+        entry={{
+          id: 'e2',
+          recipe: null,
+        }}
+      />
+    );
+
+    expect(screen.getByText('Dinner')).toBeInTheDocument();
+    expect(screen.getByText('Recipe removed')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/meal-plan/MealSlot.tsx
+++ b/frontend/src/components/meal-plan/MealSlot.tsx
@@ -1,0 +1,86 @@
+import type { MealType } from '../../types/mealPlan';
+
+interface MealSlotEntry {
+  id: string;
+  recipe: {
+    id: string;
+    title: string;
+    cookTimeMinutes?: number;
+  } | null;
+}
+
+interface MealSlotProps {
+  mealType: MealType;
+  entry: MealSlotEntry | null;
+  onAddClick?: () => void;
+  onChangeClick?: () => void;
+  onRemoveClick?: () => void;
+}
+
+const MEAL_TYPE_LABELS: Record<MealType, string> = {
+  breakfast: 'Breakfast',
+  lunch: 'Lunch',
+  dinner: 'Dinner',
+};
+
+export function MealSlot({
+  mealType,
+  entry,
+  onAddClick,
+  onChangeClick,
+  onRemoveClick,
+}: MealSlotProps) {
+  const label = MEAL_TYPE_LABELS[mealType];
+
+  if (!entry) {
+    return (
+      <div className="border border-dashed border-border rounded-lg p-3" data-testid="meal-slot">
+        <span className="text-text-secondary text-sm">{label}</span>
+        <button
+          type="button"
+          className="text-text-muted text-sm mt-1 block cursor-pointer"
+          onClick={onAddClick}
+        >
+          + Add
+        </button>
+      </div>
+    );
+  }
+
+  if (!entry.recipe) {
+    return (
+      <div className="border border-border rounded-lg p-3" data-testid="meal-slot">
+        <span className="text-text-secondary text-sm">{label}</span>
+        <p className="text-text-muted text-sm mt-1">Recipe removed</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="border border-border rounded-lg p-3 bg-card" data-testid="meal-slot">
+      <span className="text-text-secondary text-sm">{label}</span>
+      <p className="text-text-primary text-sm font-medium mt-1" data-testid="slot-recipe-name">
+        {entry.recipe.title}
+      </p>
+      {entry.recipe.cookTimeMinutes != null && (
+        <p className="text-text-muted text-xs mt-0.5">{entry.recipe.cookTimeMinutes} min</p>
+      )}
+      <div className="flex gap-2 mt-1">
+        <button
+          type="button"
+          className="text-accent text-xs cursor-pointer"
+          onClick={onChangeClick}
+        >
+          Change
+        </button>
+        <button
+          type="button"
+          className="text-text-muted text-xs cursor-pointer"
+          onClick={onRemoveClick}
+        >
+          Remove
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/meal-plan/RecipePickerModal.test.tsx
+++ b/frontend/src/components/meal-plan/RecipePickerModal.test.tsx
@@ -1,0 +1,335 @@
+import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
+import { render, screen, waitFor } from '../../test/test-utils';
+import userEvent from '@testing-library/user-event';
+import { RecipePickerModal } from './RecipePickerModal';
+import { server } from '../../test/mocks/server';
+import { http, HttpResponse } from 'msw';
+
+const BASE_URL = 'http://localhost:8000';
+
+const mockRecipeList = [
+  {
+    id: 'r1',
+    title: 'Scrambled Eggs',
+    description: 'Simple eggs',
+    ingredients: [],
+    instructions: [],
+    prep_time_minutes: 5,
+    cook_time_minutes: 10,
+    total_time_minutes: 15,
+    servings: 2,
+    cuisine_type: 'American',
+    dietary_tags: [],
+    difficulty_level: 'easy',
+    owner_id: 'u1',
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+  },
+  {
+    id: 'r2',
+    title: 'Grilled Chicken',
+    description: 'Juicy chicken',
+    ingredients: [],
+    instructions: [],
+    prep_time_minutes: 10,
+    cook_time_minutes: 25,
+    total_time_minutes: 35,
+    servings: 4,
+    cuisine_type: 'American',
+    dietary_tags: ['high-protein'],
+    difficulty_level: 'medium',
+    owner_id: 'u1',
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+  },
+  {
+    id: 'r3',
+    title: 'Pasta Carbonara',
+    description: 'Classic Italian',
+    ingredients: [],
+    instructions: [],
+    prep_time_minutes: 10,
+    cook_time_minutes: 20,
+    total_time_minutes: 30,
+    servings: 4,
+    cuisine_type: 'Italian',
+    dietary_tags: [],
+    difficulty_level: 'medium',
+    owner_id: 'u1',
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+  },
+];
+
+describe('RecipePickerModal', () => {
+  beforeAll(() => {
+    server.listen();
+    localStorage.setItem('auth_token', 'test-token');
+  });
+  afterEach(() => {
+    server.resetHandlers();
+  });
+  afterAll(() => {
+    server.close();
+    localStorage.clear();
+  });
+
+  const defaultProps = {
+    isOpen: true,
+    onClose: () => {},
+    mealType: 'breakfast' as const,
+    date: '2026-01-26',
+    mealPlanId: 'plan-1',
+    onAssign: () => {},
+  };
+
+  function setupRecipeHandler() {
+    server.use(
+      http.get(`${BASE_URL}/api/v1/recipes`, () => {
+        return HttpResponse.json({
+          recipes: mockRecipeList,
+          total: 3,
+          page: 1,
+          page_size: 50,
+          total_pages: 1,
+        });
+      })
+    );
+  }
+
+  describe('Opening and Title', () => {
+    it('should display modal with correct meal type title for empty slot', async () => {
+      setupRecipeHandler();
+      render(<RecipePickerModal {...defaultProps} mealType="breakfast" />);
+
+      expect(screen.getByRole('dialog', { name: /breakfast/i })).toBeInTheDocument();
+      expect(screen.getByRole('heading', { name: /choose.*breakfast/i })).toBeInTheDocument();
+    });
+
+    it('should display modal with correct title for lunch slot', async () => {
+      setupRecipeHandler();
+      render(<RecipePickerModal {...defaultProps} mealType="lunch" />);
+
+      expect(screen.getByRole('heading', { name: /choose.*lunch/i })).toBeInTheDocument();
+    });
+
+    it('should not render when isOpen is false', () => {
+      render(<RecipePickerModal {...defaultProps} isOpen={false} />);
+
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Recipe List', () => {
+    it('should render recipe list from API data', async () => {
+      setupRecipeHandler();
+      render(<RecipePickerModal {...defaultProps} />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Scrambled Eggs')).toBeInTheDocument();
+        expect(screen.getByText('Grilled Chicken')).toBeInTheDocument();
+        expect(screen.getByText('Pasta Carbonara')).toBeInTheDocument();
+      });
+    });
+
+    it('should show empty state when no recipes exist', async () => {
+      server.use(
+        http.get(`${BASE_URL}/api/v1/recipes`, () => {
+          return HttpResponse.json({
+            recipes: [],
+            total: 0,
+            page: 1,
+            page_size: 50,
+            total_pages: 0,
+          });
+        })
+      );
+
+      render(<RecipePickerModal {...defaultProps} />);
+
+      await waitFor(() => {
+        expect(screen.getByText(/no recipes/i)).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('Search', () => {
+    it('should filter displayed recipes when user types in search input', async () => {
+      setupRecipeHandler();
+      const user = userEvent.setup();
+
+      render(<RecipePickerModal {...defaultProps} />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Scrambled Eggs')).toBeInTheDocument();
+      });
+
+      const searchInput = screen.getByRole('textbox', { name: /search/i });
+      await user.type(searchInput, 'chicken');
+
+      await waitFor(() => {
+        expect(screen.getByText('Grilled Chicken')).toBeInTheDocument();
+        expect(screen.queryByText('Scrambled Eggs')).not.toBeInTheDocument();
+        expect(screen.queryByText('Pasta Carbonara')).not.toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('Assign Recipe', () => {
+    it('should call PUT and update slot when recipe is selected', async () => {
+      setupRecipeHandler();
+
+      let assignedRecipeId: string | null = null;
+      server.use(
+        http.put(`${BASE_URL}/api/v1/meal-plans/:planId/entries`, async ({ request }) => {
+          const body = (await request.json()) as { recipe_id: string };
+          assignedRecipeId = body.recipe_id;
+          return HttpResponse.json({
+            id: 'entry-new',
+            day_of_week: 0,
+            meal_type: 'breakfast',
+            recipe: { id: body.recipe_id, title: 'Grilled Chicken', cook_time_minutes: 25 },
+          });
+        })
+      );
+
+      const onAssign = () => {};
+      const user = userEvent.setup();
+
+      render(<RecipePickerModal {...defaultProps} onAssign={onAssign} />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Grilled Chicken')).toBeInTheDocument();
+      });
+
+      // Click a recipe to select it
+      await user.click(screen.getByText('Grilled Chicken'));
+
+      await waitFor(() => {
+        expect(assignedRecipeId).toBe('r2');
+      });
+    });
+
+    it('should close modal after successful assignment', async () => {
+      setupRecipeHandler();
+
+      server.use(
+        http.put(`${BASE_URL}/api/v1/meal-plans/:planId/entries`, async ({ request }) => {
+          const body = (await request.json()) as Record<string, unknown>;
+          return HttpResponse.json({
+            id: 'entry-new',
+            day_of_week: 0,
+            meal_type: 'breakfast',
+            recipe: { id: body.recipe_id, title: 'Grilled Chicken', cook_time_minutes: 25 },
+          });
+        })
+      );
+
+      let closed = false;
+      const user = userEvent.setup();
+
+      render(
+        <RecipePickerModal
+          {...defaultProps}
+          onClose={() => {
+            closed = true;
+          }}
+        />
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText('Grilled Chicken')).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByText('Grilled Chicken'));
+
+      await waitFor(() => {
+        expect(closed).toBe(true);
+      });
+    });
+  });
+
+  describe('Error Handling', () => {
+    it('should display error message on mutation failure', async () => {
+      setupRecipeHandler();
+
+      server.use(
+        http.put(`${BASE_URL}/api/v1/meal-plans/:planId/entries`, () => {
+          return HttpResponse.json({ detail: 'Internal server error' }, { status: 500 });
+        })
+      );
+
+      const user = userEvent.setup();
+
+      render(<RecipePickerModal {...defaultProps} />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Grilled Chicken')).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByText('Grilled Chicken'));
+
+      await waitFor(() => {
+        expect(screen.getByText(/error|failed/i)).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('Closing Behavior', () => {
+    it('should close when Escape key is pressed', async () => {
+      setupRecipeHandler();
+
+      let closed = false;
+      const user = userEvent.setup();
+
+      render(
+        <RecipePickerModal
+          {...defaultProps}
+          onClose={() => {
+            closed = true;
+          }}
+        />
+      );
+
+      await user.keyboard('{Escape}');
+
+      expect(closed).toBe(true);
+    });
+
+    it('should close when overlay is clicked', async () => {
+      setupRecipeHandler();
+
+      let closed = false;
+      const user = userEvent.setup();
+
+      render(
+        <RecipePickerModal
+          {...defaultProps}
+          onClose={() => {
+            closed = true;
+          }}
+        />
+      );
+
+      // Click the overlay (the backdrop behind the modal)
+      const dialog = screen.getByRole('dialog');
+      // Click outside the modal content - the overlay
+      await user.click(dialog.parentElement!);
+
+      expect(closed).toBe(true);
+    });
+  });
+
+  describe('Focus Management', () => {
+    it('should move focus into the modal when opened', async () => {
+      setupRecipeHandler();
+
+      render(<RecipePickerModal {...defaultProps} />);
+
+      await waitFor(() => {
+        const dialog = screen.getByRole('dialog');
+        expect(dialog.contains(document.activeElement)).toBe(true);
+      });
+    });
+  });
+});

--- a/frontend/src/components/meal-plan/RecipePickerModal.tsx
+++ b/frontend/src/components/meal-plan/RecipePickerModal.tsx
@@ -1,0 +1,189 @@
+import { useState, useEffect, useRef, useCallback } from 'react';
+import type { MealType } from '../../types/mealPlan';
+import { getRecipes } from '../../services/recipeApi';
+import { upsertMealPlanEntry } from '../../services/mealPlanApi';
+
+interface RecipePickerModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  mealType: MealType;
+  date: string;
+  mealPlanId: string;
+  onAssign: () => void;
+}
+
+interface RecipeItem {
+  id: string;
+  title: string;
+}
+
+export function RecipePickerModal({
+  isOpen,
+  onClose,
+  mealType,
+  date,
+  mealPlanId,
+  onAssign,
+}: RecipePickerModalProps) {
+  const [recipes, setRecipes] = useState<RecipeItem[]>([]);
+  const [search, setSearch] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [fetchError, setFetchError] = useState(false);
+  const dialogRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const fetchData = async () => {
+      setSearch('');
+      setError(null);
+      setFetchError(false);
+      try {
+        const res = await getRecipes({ page_size: 50 });
+        setRecipes(res.data.map((r) => ({ id: r.id, title: r.title })));
+      } catch {
+        setRecipes([]);
+        setFetchError(true);
+      }
+    };
+    fetchData();
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (isOpen && dialogRef.current) {
+      dialogRef.current.focus();
+    }
+  }, [isOpen, recipes]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        onClose();
+      }
+      if (e.key === 'Tab') {
+        const dialog = dialogRef.current;
+        if (!dialog) return;
+        const focusable = dialog.querySelectorAll<HTMLElement>(
+          'input, button, [tabindex]:not([tabindex="-1"]), a[href]'
+        );
+        if (focusable.length === 0) return;
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+        if (e.shiftKey) {
+          if (document.activeElement === first || document.activeElement === dialog) {
+            e.preventDefault();
+            last.focus();
+          }
+        } else {
+          if (document.activeElement === last) {
+            e.preventDefault();
+            first.focus();
+          }
+        }
+      }
+    },
+    [onClose]
+  );
+
+  const handleOverlayClick = useCallback(
+    (e: React.MouseEvent) => {
+      if (e.target === e.currentTarget) {
+        onClose();
+      }
+    },
+    [onClose]
+  );
+
+  const handleSelect = useCallback(
+    async (recipeId: string) => {
+      setError(null);
+      try {
+        await upsertMealPlanEntry(mealPlanId, {
+          date,
+          meal_type: mealType,
+          recipe_id: recipeId,
+        });
+        onAssign();
+        onClose();
+      } catch {
+        setError('Failed to assign recipe.');
+      }
+    },
+    [mealPlanId, date, mealType, onAssign, onClose]
+  );
+
+  const handleItemKeyDown = useCallback(
+    (e: React.KeyboardEvent, recipeId: string) => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        handleSelect(recipeId);
+      }
+    },
+    [handleSelect]
+  );
+
+  if (!isOpen) return null;
+
+  const filtered = search
+    ? recipes.filter((r) => r.title.toLowerCase().includes(search.toLowerCase()))
+    : recipes;
+
+  const title = `Choose ${mealType}`;
+
+  return (
+    <div
+      data-testid="modal-overlay"
+      onClick={handleOverlayClick}
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+    >
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-label={title}
+        tabIndex={-1}
+        onKeyDown={handleKeyDown}
+        data-testid="recipe-picker-modal"
+        className="bg-card border border-border rounded-lg shadow-lg p-6 w-full max-w-md mx-4"
+      >
+        <h2 className="text-lg font-semibold text-text-primary mb-4">{title}</h2>
+
+        {error && <p className="text-error mb-2">{error}</p>}
+
+        <label htmlFor="recipe-search" className="sr-only">
+          Search
+        </label>
+        <input
+          id="recipe-search"
+          type="text"
+          aria-label="Search"
+          placeholder="Search recipes..."
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          className="w-full px-3 py-2 border border-border rounded-md bg-card text-text-primary mb-3 focus:outline-none focus:ring-2 focus:ring-accent-subtle"
+        />
+
+        {fetchError && <p className="text-error">Failed to load recipes.</p>}
+        {!fetchError && filtered.length === 0 && (
+          <p className="text-text-secondary">No recipes found.</p>
+        )}
+
+        <ul data-testid="recipe-picker-list" role="listbox">
+          {filtered.map((r) => (
+            <li
+              key={r.id}
+              data-testid="recipe-picker-item"
+              role="option"
+              aria-selected={false}
+              tabIndex={0}
+              onClick={() => handleSelect(r.id)}
+              onKeyDown={(e) => handleItemKeyDown(e, r.id)}
+              className="cursor-pointer px-3 py-2 rounded hover:bg-hover text-text-primary"
+            >
+              {r.title}
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/meal-plan/WeekNavigation.test.tsx
+++ b/frontend/src/components/meal-plan/WeekNavigation.test.tsx
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '../../test/test-utils';
+import userEvent from '@testing-library/user-event';
+import { WeekNavigation } from './WeekNavigation';
+
+// Helper: get Monday of current week
+function getCurrentWeekMonday(): Date {
+  const now = new Date();
+  const day = now.getDay(); // 0=Sun, 1=Mon, ...
+  const diff = day === 0 ? -6 : 1 - day;
+  const monday = new Date(now);
+  monday.setDate(now.getDate() + diff);
+  monday.setHours(0, 0, 0, 0);
+  return monday;
+}
+
+function formatDateLabel(weekStart: Date): RegExp {
+  // Expected format: "Mon DD - Sun DD" e.g. "Jan 26 - Feb 1"
+  const months = [
+    'Jan',
+    'Feb',
+    'Mar',
+    'Apr',
+    'May',
+    'Jun',
+    'Jul',
+    'Aug',
+    'Sep',
+    'Oct',
+    'Nov',
+    'Dec',
+  ];
+  const startMonth = months[weekStart.getMonth()];
+  const startDay = String(weekStart.getDate()).padStart(2, '0');
+  const endDate = new Date(weekStart);
+  endDate.setDate(endDate.getDate() + 6);
+  const endMonth = months[endDate.getMonth()];
+  const endDay = String(endDate.getDate()).padStart(2, '0');
+  return new RegExp(`${startMonth}\\s+${startDay}\\s*[-\u2013]\\s*${endMonth}\\s+${endDay}`);
+}
+
+function getNextWeekMonday(weekStart: Date): Date {
+  const next = new Date(weekStart);
+  next.setDate(next.getDate() + 7);
+  return next;
+}
+
+function getPrevWeekMonday(weekStart: Date): Date {
+  const prev = new Date(weekStart);
+  prev.setDate(prev.getDate() - 7);
+  return prev;
+}
+
+describe('WeekNavigation', () => {
+  const currentMonday = getCurrentWeekMonday();
+  const defaultProps = {
+    weekStart: currentMonday,
+    onWeekChange: vi.fn(),
+  };
+
+  it('should render prev button, next button, Today button, and date label', () => {
+    render(<WeekNavigation {...defaultProps} />);
+
+    expect(screen.getByRole('button', { name: /prev/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /next/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /today/i })).toBeInTheDocument();
+    expect(screen.getByText(formatDateLabel(currentMonday))).toBeInTheDocument();
+  });
+
+  it('should display date label in "Mon DD - Sun DD" format', () => {
+    render(<WeekNavigation {...defaultProps} />);
+
+    // The label should match the pattern for the current week
+    expect(screen.getByText(formatDateLabel(currentMonday))).toBeInTheDocument();
+  });
+
+  it('should call onWeekChange with next week when clicking next button', async () => {
+    const onWeekChange = vi.fn();
+    const user = userEvent.setup();
+
+    render(<WeekNavigation weekStart={currentMonday} onWeekChange={onWeekChange} />);
+
+    await user.click(screen.getByRole('button', { name: /next/i }));
+
+    const expectedNext = getNextWeekMonday(currentMonday);
+    expect(onWeekChange).toHaveBeenCalledWith(expectedNext);
+  });
+
+  it('should call onWeekChange with previous week when clicking prev button', async () => {
+    const onWeekChange = vi.fn();
+    const user = userEvent.setup();
+
+    render(<WeekNavigation weekStart={currentMonday} onWeekChange={onWeekChange} />);
+
+    await user.click(screen.getByRole('button', { name: /prev/i }));
+
+    const expectedPrev = getPrevWeekMonday(currentMonday);
+    expect(onWeekChange).toHaveBeenCalledWith(expectedPrev);
+  });
+
+  it('should call onWeekChange with current week Monday when clicking Today button', async () => {
+    const onWeekChange = vi.fn();
+    const user = userEvent.setup();
+    // Start on a different week so Today button is actionable
+    const pastMonday = getPrevWeekMonday(currentMonday);
+
+    render(<WeekNavigation weekStart={pastMonday} onWeekChange={onWeekChange} />);
+
+    await user.click(screen.getByRole('button', { name: /today/i }));
+
+    expect(onWeekChange).toHaveBeenCalledWith(currentMonday);
+  });
+
+  it('should disable Today button when already on current week', () => {
+    render(<WeekNavigation {...defaultProps} />);
+
+    const todayButton = screen.getByRole('button', { name: /today/i });
+    expect(todayButton).toBeDisabled();
+  });
+
+  it('should enable Today button when on a different week', () => {
+    const pastMonday = getPrevWeekMonday(currentMonday);
+
+    render(<WeekNavigation weekStart={pastMonday} onWeekChange={vi.fn()} />);
+
+    const todayButton = screen.getByRole('button', { name: /today/i });
+    expect(todayButton).toBeEnabled();
+  });
+});

--- a/frontend/src/components/meal-plan/WeekNavigation.tsx
+++ b/frontend/src/components/meal-plan/WeekNavigation.tsx
@@ -1,0 +1,74 @@
+export interface WeekNavigationProps {
+  weekStart: Date;
+  onWeekChange: (newWeekStart: Date) => void;
+}
+
+import { getCurrentWeekMonday } from '../../utils/dateUtils';
+
+function formatDateLabel(weekStart: Date): string {
+  const months = [
+    'Jan',
+    'Feb',
+    'Mar',
+    'Apr',
+    'May',
+    'Jun',
+    'Jul',
+    'Aug',
+    'Sep',
+    'Oct',
+    'Nov',
+    'Dec',
+  ];
+  const startMonth = months[weekStart.getMonth()];
+  const startDay = String(weekStart.getDate()).padStart(2, '0');
+  const endDate = new Date(weekStart);
+  endDate.setDate(endDate.getDate() + 6);
+  const endMonth = months[endDate.getMonth()];
+  const endDay = String(endDate.getDate()).padStart(2, '0');
+  return `${startMonth} ${startDay} - ${endMonth} ${endDay}`;
+}
+
+function isSameDate(a: Date, b: Date): boolean {
+  return (
+    a.getFullYear() === b.getFullYear() &&
+    a.getMonth() === b.getMonth() &&
+    a.getDate() === b.getDate()
+  );
+}
+
+export function WeekNavigation({ weekStart, onWeekChange }: WeekNavigationProps) {
+  const currentMonday = getCurrentWeekMonday();
+  const isCurrentWeek = isSameDate(weekStart, currentMonday);
+
+  const handlePrev = () => {
+    const prev = new Date(weekStart);
+    prev.setDate(prev.getDate() - 7);
+    onWeekChange(prev);
+  };
+
+  const handleNext = () => {
+    const next = new Date(weekStart);
+    next.setDate(next.getDate() + 7);
+    onWeekChange(next);
+  };
+
+  const handleToday = () => {
+    onWeekChange(currentMonday);
+  };
+
+  return (
+    <nav className="flex items-center gap-2">
+      <button onClick={handlePrev} aria-label="Previous week">
+        Prev
+      </button>
+      <button onClick={handleToday} disabled={isCurrentWeek} aria-label="Today">
+        Today
+      </button>
+      <button onClick={handleNext} aria-label="Next week">
+        Next
+      </button>
+      <span data-testid="week-date-range">{formatDateLabel(weekStart)}</span>
+    </nav>
+  );
+}

--- a/frontend/src/pages/MealPlanPage.test.tsx
+++ b/frontend/src/pages/MealPlanPage.test.tsx
@@ -1,0 +1,166 @@
+import { describe, it, expect, beforeEach, afterEach, beforeAll, afterAll } from 'vitest';
+import { render, screen, waitFor } from '../test/test-utils';
+import MealPlanPage from './MealPlanPage';
+import { server } from '../test/mocks/server';
+import { http, HttpResponse } from 'msw';
+import { mockMealPlanWeek, mockMealPlanEntry } from '../test/mocks/mealPlanData';
+
+const BASE_URL = 'http://localhost:8000';
+
+describe('MealPlanPage', () => {
+  beforeAll(() => server.listen());
+  beforeEach(() => {
+    localStorage.setItem('auth_token', 'test-token');
+  });
+  afterEach(() => {
+    server.resetHandlers();
+    localStorage.clear();
+  });
+  afterAll(() => server.close());
+
+  describe('Layout', () => {
+    it('should render 7 days with correct day names', async () => {
+      render(<MealPlanPage />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Monday')).toBeInTheDocument();
+        expect(screen.getByText('Tuesday')).toBeInTheDocument();
+        expect(screen.getByText('Wednesday')).toBeInTheDocument();
+        expect(screen.getByText('Thursday')).toBeInTheDocument();
+        expect(screen.getByText('Friday')).toBeInTheDocument();
+        expect(screen.getByText('Saturday')).toBeInTheDocument();
+        expect(screen.getByText('Sunday')).toBeInTheDocument();
+      });
+    });
+
+    it('should show 3 meal slots per day (Breakfast, Lunch, Dinner)', async () => {
+      render(<MealPlanPage />);
+
+      await waitFor(() => {
+        const breakfastSlots = screen.getAllByText('Breakfast');
+        const lunchSlots = screen.getAllByText('Lunch');
+        const dinnerSlots = screen.getAllByText('Dinner');
+
+        expect(breakfastSlots).toHaveLength(7);
+        expect(lunchSlots).toHaveLength(7);
+        expect(dinnerSlots).toHaveLength(7);
+      });
+    });
+
+    it("should highlight today's column with accent styling", async () => {
+      render(<MealPlanPage />);
+
+      await waitFor(() => {
+        const todayColumn = screen.getByTestId('day-column-today');
+        expect(todayColumn).toBeInTheDocument();
+        expect(todayColumn.className).toMatch(/accent|today|highlight/);
+      });
+    });
+  });
+
+  describe('Empty Slots', () => {
+    it('should render "+ Add" text with meal type label for empty slots', async () => {
+      server.use(
+        http.get(`${BASE_URL}/api/v1/meal-plans`, () => {
+          return HttpResponse.json(mockMealPlanWeek({ entries: [] }));
+        })
+      );
+
+      render(<MealPlanPage />);
+
+      await waitFor(() => {
+        // 7 days * 3 meals = 21 empty slots, each showing "+ Add"
+        const addButtons = screen.getAllByText(/\+ Add/);
+        expect(addButtons).toHaveLength(21);
+      });
+    });
+  });
+
+  describe('Filled Slots', () => {
+    it('should render recipe name and cook time for filled slots', async () => {
+      server.use(
+        http.get(`${BASE_URL}/api/v1/meal-plans`, () => {
+          return HttpResponse.json(
+            mockMealPlanWeek({
+              entries: [
+                mockMealPlanEntry({
+                  day_of_week: 0,
+                  meal_type: 'breakfast',
+                  recipe: {
+                    id: 'r1',
+                    title: 'Scrambled Eggs',
+                    cook_time_minutes: 10,
+                  },
+                }),
+              ],
+            })
+          );
+        })
+      );
+
+      render(<MealPlanPage />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Scrambled Eggs')).toBeInTheDocument();
+        expect(screen.getByText(/10 min/)).toBeInTheDocument();
+      });
+    });
+
+    it('should show "Recipe removed" for slots with null recipe', async () => {
+      server.use(
+        http.get(`${BASE_URL}/api/v1/meal-plans`, () => {
+          return HttpResponse.json(
+            mockMealPlanWeek({
+              entries: [
+                mockMealPlanEntry({
+                  day_of_week: 0,
+                  meal_type: 'breakfast',
+                  recipe: null,
+                }),
+              ],
+            })
+          );
+        })
+      );
+
+      render(<MealPlanPage />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Recipe removed')).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('Loading State', () => {
+    it('should show loading state while fetching meal plan', async () => {
+      server.use(
+        http.get(`${BASE_URL}/api/v1/meal-plans`, () => {
+          // Delay response to observe loading state
+          return new Promise(() => {
+            // Never resolve - we just want to see loading
+          });
+        })
+      );
+
+      render(<MealPlanPage />);
+
+      expect(screen.getByText(/loading/i)).toBeInTheDocument();
+    });
+  });
+
+  describe('Error State', () => {
+    it('should show error state on API failure', async () => {
+      server.use(
+        http.get(`${BASE_URL}/api/v1/meal-plans`, () => {
+          return HttpResponse.json({ detail: 'Internal server error' }, { status: 500 });
+        })
+      );
+
+      render(<MealPlanPage />);
+
+      await waitFor(() => {
+        expect(screen.getByText(/error/i)).toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/frontend/src/pages/MealPlanPage.tsx
+++ b/frontend/src/pages/MealPlanPage.tsx
@@ -1,0 +1,169 @@
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { DayColumn } from '../components/meal-plan/DayColumn';
+import { RecipePickerModal } from '../components/meal-plan/RecipePickerModal';
+import { WeekNavigation } from '../components/meal-plan/WeekNavigation';
+import { fetchCurrentMealPlan, deleteMealPlanEntry } from '../services/mealPlanApi';
+import type { MealPlan, MealType } from '../types/mealPlan';
+
+const DAY_NAMES = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'];
+
+import { getCurrentWeekMonday } from '../utils/dateUtils';
+
+function formatWeekStartParam(date: Date): string {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, '0');
+  const d = String(date.getDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
+}
+
+function getWeekDates(weekStart: string): string[] {
+  const start = new Date(weekStart + 'T00:00:00');
+  return DAY_NAMES.map((_, i) => {
+    const d = new Date(start);
+    d.setDate(d.getDate() + i);
+    return d.toISOString().split('T')[0];
+  });
+}
+
+function getTodayDayIndex(dates: string[]): number {
+  const today = new Date().toISOString().split('T')[0];
+  return dates.findIndex((d) => d === today);
+}
+
+interface ModalState {
+  isOpen: boolean;
+  mealType: MealType;
+  dayIndex: number;
+}
+
+export default function MealPlanPage() {
+  const [weekStart, setWeekStart] = useState<Date>(getCurrentWeekMonday);
+  const [mealPlan, setMealPlan] = useState<MealPlan | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [modal, setModal] = useState<ModalState>({
+    isOpen: false,
+    mealType: 'breakfast',
+    dayIndex: 0,
+  });
+  const fetchCounterRef = useRef(0);
+  const [reloadKey, setReloadKey] = useState(0);
+
+  useEffect(() => {
+    const requestId = ++fetchCounterRef.current;
+    const loadMealPlan = async () => {
+      setLoading(true);
+      try {
+        const data = await fetchCurrentMealPlan(formatWeekStartParam(weekStart));
+        if (requestId !== fetchCounterRef.current) return;
+        setMealPlan(data);
+      } catch {
+        if (requestId !== fetchCounterRef.current) return;
+        setError('Error loading meal plan');
+      } finally {
+        if (requestId === fetchCounterRef.current) {
+          setLoading(false);
+        }
+      }
+    };
+    loadMealPlan();
+  }, [weekStart, reloadKey]);
+
+  const reload = useCallback(() => setReloadKey((k) => k + 1), []);
+
+  const handleSlotClick = useCallback((dayIndex: number, mealType: MealType) => {
+    setModal({ isOpen: true, mealType, dayIndex });
+  }, []);
+
+  const handleModalClose = useCallback(() => {
+    setModal((prev) => ({ ...prev, isOpen: false }));
+  }, []);
+
+  const handleAssign = useCallback(() => {
+    reload();
+  }, [reload]);
+
+  const handleRemove = useCallback(
+    async (entryId: string) => {
+      if (!mealPlan) return;
+      try {
+        await deleteMealPlanEntry(mealPlan.id, entryId);
+        reload();
+      } catch {
+        // Could show error toast
+      }
+    },
+    [mealPlan, reload]
+  );
+
+  const handleWeekChange = useCallback((newWeekStart: Date) => {
+    setWeekStart(newWeekStart);
+  }, []);
+
+  const dates = mealPlan ? getWeekDates(mealPlan.weekStart) : [];
+  const todayIndex = mealPlan ? getTodayDayIndex(dates) : -1;
+
+  const renderContent = () => {
+    if (loading) {
+      return <div className="text-text-secondary">Loading...</div>;
+    }
+    if (error) {
+      return <div className="text-text-secondary">{error}</div>;
+    }
+    if (!mealPlan) {
+      return null;
+    }
+    return (
+      <>
+        <div
+          className="grid grid-cols-1 md:grid-cols-7 gap-2 mt-4"
+          data-testid="meal-plan-calendar"
+        >
+          {DAY_NAMES.map((dayName, i) => {
+            const dayEntries = mealPlan.entries
+              .filter((e) => e.dayOfWeek === i)
+              .map((e) => ({
+                id: e.id,
+                meal_type: e.mealType,
+                recipe: e.recipe
+                  ? {
+                      id: e.recipe.id,
+                      title: e.recipe.title,
+                      cook_time_minutes: e.recipe.cookTimeMinutes,
+                    }
+                  : null,
+              }));
+
+            return (
+              <DayColumn
+                key={dayName}
+                dayName={dayName}
+                date={dates[i]}
+                entries={dayEntries}
+                isToday={i === todayIndex}
+                onSlotClick={(mealType) => handleSlotClick(i, mealType)}
+                onRemoveClick={(entryId) => handleRemove(entryId)}
+              />
+            );
+          })}
+        </div>
+        <RecipePickerModal
+          isOpen={modal.isOpen}
+          onClose={handleModalClose}
+          mealType={modal.mealType}
+          date={dates[modal.dayIndex]}
+          mealPlanId={mealPlan.id}
+          onAssign={handleAssign}
+        />
+      </>
+    );
+  };
+
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl font-bold text-text-primary mb-4">Meal Plan</h1>
+      <WeekNavigation weekStart={weekStart} onWeekChange={handleWeekChange} />
+      {renderContent()}
+    </div>
+  );
+}

--- a/frontend/src/services/mealPlanApi.ts
+++ b/frontend/src/services/mealPlanApi.ts
@@ -1,0 +1,74 @@
+import apiClient from './api';
+import type { MealPlan, MealPlanEntry } from '../types/mealPlan';
+
+interface BackendMealPlanResponse {
+  id: string;
+  week_start: string;
+  entries: {
+    id: string;
+    day_of_week: number;
+    meal_type: 'breakfast' | 'lunch' | 'dinner';
+    recipe: { id: string; title: string; cook_time_minutes: number } | null;
+  }[];
+  created_at: string;
+  updated_at: string;
+}
+
+function transformMealPlan(data: BackendMealPlanResponse): MealPlan {
+  return {
+    id: data.id,
+    weekStart: data.week_start,
+    entries: data.entries.map(
+      (e): MealPlanEntry => ({
+        id: e.id,
+        dayOfWeek: e.day_of_week,
+        mealType: e.meal_type,
+        recipe: e.recipe
+          ? {
+              id: e.recipe.id,
+              title: e.recipe.title,
+              cookTimeMinutes: e.recipe.cook_time_minutes,
+            }
+          : null,
+      })
+    ),
+    createdAt: data.created_at,
+    updatedAt: data.updated_at,
+  };
+}
+
+export async function fetchCurrentMealPlan(weekStart?: string): Promise<MealPlan> {
+  if (weekStart) {
+    const response = await apiClient.get<BackendMealPlanResponse>('/api/v1/meal-plans', {
+      params: { week_start: weekStart },
+    });
+    return transformMealPlan(response.data);
+  }
+  const response = await apiClient.get<BackendMealPlanResponse>('/api/v1/meal-plans/current');
+  return transformMealPlan(response.data);
+}
+
+export async function upsertMealPlanEntry(
+  planId: string,
+  data: { date: string; meal_type: string; recipe_id: string }
+): Promise<MealPlanEntry> {
+  const response = await apiClient.put<{
+    id: string;
+    day_of_week: number;
+    meal_type: 'breakfast' | 'lunch' | 'dinner';
+    recipe: { id: string; title: string; cook_time_minutes: number } | null;
+  }>(`/api/v1/meal-plans/${planId}/entries`, data);
+  const e = response.data;
+  return {
+    id: e.id,
+    dayOfWeek: e.day_of_week,
+    mealType: e.meal_type,
+    recipe: e.recipe
+      ? { id: e.recipe.id, title: e.recipe.title, cookTimeMinutes: e.recipe.cook_time_minutes }
+      : null,
+  };
+}
+
+export async function deleteMealPlanEntry(planId: string, entryId: string): Promise<void> {
+  await apiClient.delete(`/api/v1/meal-plans/${planId}/entries/${entryId}`);
+}

--- a/frontend/src/test/mocks/handlers.ts
+++ b/frontend/src/test/mocks/handlers.ts
@@ -6,6 +6,7 @@ import {
   mockShareTokenResponse,
   mockLoginResponse,
 } from './data';
+import { mockMealPlanWeek } from './mealPlanData';
 
 const BASE_URL = 'http://localhost:8000';
 
@@ -257,6 +258,17 @@ export const handlers = [
       message: body.message,
       created_at: new Date().toISOString(),
     });
+  }),
+
+  // Meal plan endpoints
+  http.get(`${BASE_URL}/api/v1/meal-plans/current`, () => {
+    return HttpResponse.json(mockMealPlanWeek());
+  }),
+
+  http.get(`${BASE_URL}/api/v1/meal-plans`, ({ request }) => {
+    const url = new URL(request.url);
+    const weekStart = url.searchParams.get('week_start');
+    return HttpResponse.json(mockMealPlanWeek(weekStart ? { week_start: weekStart } : undefined));
   }),
 
   // Chat endpoint

--- a/frontend/src/test/mocks/mealPlanData.ts
+++ b/frontend/src/test/mocks/mealPlanData.ts
@@ -1,0 +1,59 @@
+/**
+ * Mock data factories for meal plan tests.
+ * Backend returns snake_case; these match real API responses.
+ */
+
+export interface MockMealPlanRecipe {
+  id: string;
+  title: string;
+  cook_time_minutes: number;
+}
+
+export interface MockMealPlanEntry {
+  id: string;
+  day_of_week: number; // 0=Monday, 6=Sunday
+  meal_type: 'breakfast' | 'lunch' | 'dinner';
+  recipe: MockMealPlanRecipe | null;
+}
+
+export interface MockMealPlanWeek {
+  id: string;
+  week_start: string; // ISO date string (Monday)
+  entries: MockMealPlanEntry[];
+  created_at: string;
+  updated_at: string;
+}
+
+export const mockMealPlanEntry = (overrides?: Partial<MockMealPlanEntry>): MockMealPlanEntry => ({
+  id: 'entry-1',
+  day_of_week: 0,
+  meal_type: 'breakfast',
+  recipe: {
+    id: 'r1',
+    title: 'Test Meal',
+    cook_time_minutes: 20,
+  },
+  ...overrides,
+});
+
+export const mockMealPlanWeek = (overrides?: Partial<MockMealPlanWeek>): MockMealPlanWeek => ({
+  id: 'plan-1',
+  week_start: '2026-01-26',
+  entries: [
+    mockMealPlanEntry({
+      id: 'entry-1',
+      day_of_week: 0,
+      meal_type: 'breakfast',
+      recipe: { id: 'r1', title: 'Scrambled Eggs', cook_time_minutes: 10 },
+    }),
+    mockMealPlanEntry({
+      id: 'entry-2',
+      day_of_week: 2,
+      meal_type: 'dinner',
+      recipe: { id: 'r2', title: 'Grilled Chicken', cook_time_minutes: 30 },
+    }),
+  ],
+  created_at: new Date().toISOString(),
+  updated_at: new Date().toISOString(),
+  ...overrides,
+});

--- a/frontend/src/types/mealPlan.ts
+++ b/frontend/src/types/mealPlan.ts
@@ -1,0 +1,22 @@
+export type MealType = 'breakfast' | 'lunch' | 'dinner';
+
+export interface MealPlanRecipe {
+  id: string;
+  title: string;
+  cookTimeMinutes: number;
+}
+
+export interface MealPlanEntry {
+  id: string;
+  dayOfWeek: number;
+  mealType: MealType;
+  recipe: MealPlanRecipe | null;
+}
+
+export interface MealPlan {
+  id: string;
+  weekStart: string;
+  entries: MealPlanEntry[];
+  createdAt: string;
+  updatedAt: string;
+}

--- a/frontend/src/utils/dateUtils.ts
+++ b/frontend/src/utils/dateUtils.ts
@@ -1,0 +1,12 @@
+/**
+ * Returns the Monday of the current week with time set to midnight.
+ */
+export function getCurrentWeekMonday(): Date {
+  const now = new Date();
+  const day = now.getDay();
+  const diff = day === 0 ? -6 : 1 - day;
+  const monday = new Date(now);
+  monday.setDate(now.getDate() + diff);
+  monday.setHours(0, 0, 0, 0);
+  return monday;
+}


### PR DESCRIPTION
## Summary
- Adds full meal planning feature: backend API (model, schema, service, endpoints, migration), frontend weekly calendar view with recipe assignment, and E2E test coverage
- Replaces the "Coming Soon" placeholder on `/planning` with a functional `MealPlanPage`
- Includes week navigation, day columns with meal slots, and a recipe picker modal

Closes #26

## Test plan
- [ ] Backend integration tests pass (`test_meal_plans_api.py`)
- [ ] Frontend unit tests pass (DayColumn, MealSlot, WeekNavigation, RecipePickerModal, MealPlanPage)
- [ ] E2E specs pass (meal-plan, meal-plan-recipes, meal-plan-week-nav)
- [ ] Manual: navigate to /planning, verify weekly view renders with meal slots

🤖 Generated with [Claude Code](https://claude.com/claude-code)