### PR TITLE
feat: replace placeholder data with real API-driven content

### DIFF
--- a/backend/app/api/libraries.py
+++ b/backend/app/api/libraries.py
@@ -53,7 +53,19 @@ async def list_libraries(
         skip=skip,
         limit=limit,
     )
-    return libraries
+    return [
+        LibraryResponse(
+            id=lib.id,
+            name=lib.name,
+            description=lib.description,
+            is_public=lib.is_public,
+            owner_id=lib.owner_id,
+            recipe_count=len(lib.recipes) if lib.recipes else 0,
+            created_at=lib.created_at,
+            updated_at=lib.updated_at,
+        )
+        for lib in libraries
+    ]
 
 
 @router.post("", response_model=LibraryResponse, status_code=status.HTTP_201_CREATED)

--- a/backend/app/api/meal_plans.py
+++ b/backend/app/api/meal_plans.py
@@ -43,6 +43,12 @@ def _build_entry_response(e: object) -> MealPlanEntryResponse:
                 id=e.recipe.id,
                 title=e.recipe.title,
                 cook_time_minutes=e.recipe.cook_time_minutes,
+                servings=e.recipe.servings,
+                difficulty_level=(
+                    e.recipe.difficulty_level.value
+                    if e.recipe.difficulty_level
+                    else None
+                ),
             )
             if e.recipe
             else None

--- a/backend/app/schemas/library.py
+++ b/backend/app/schemas/library.py
@@ -37,6 +37,7 @@ class LibraryResponse(LibraryBase):
 
     id: str
     owner_id: str
+    recipe_count: int = 0
     created_at: datetime
     updated_at: datetime
 

--- a/backend/app/schemas/meal_plan.py
+++ b/backend/app/schemas/meal_plan.py
@@ -14,6 +14,8 @@ class RecipeRef(BaseModel):
     id: str
     title: str
     cook_time_minutes: Optional[int] = None
+    servings: Optional[int] = None
+    difficulty_level: Optional[str] = None
 
 
 class MealPlanEntryResponse(BaseModel):

--- a/backend/app/services/library_service.py
+++ b/backend/app/services/library_service.py
@@ -54,7 +54,7 @@ async def get_libraries(
     Returns:
         List of libraries
     """
-    query = select(RecipeLibrary)
+    query = select(RecipeLibrary).options(selectinload(RecipeLibrary.recipes))
 
     if owner_id:
         query = query.where(RecipeLibrary.owner_id == owner_id)

--- a/backend/tests/integration/test_response_enrichment_api.py
+++ b/backend/tests/integration/test_response_enrichment_api.py
@@ -1,0 +1,163 @@
+"""
+Integration Tests for API Response Enrichment (Issue #38, Story 2)
+
+Tests that meal plan entries include enriched recipe fields (servings,
+difficulty_level) and library list responses include recipe_count.
+"""
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+
+class TestMealPlanEntryRecipeEnrichment:
+    """Meal plan entry responses should include servings and difficulty_level in recipe ref."""
+
+    async def _create_plan_with_recipe_entry(
+        self,
+        client: AsyncClient,
+        auth_headers: dict,
+        test_recipe,
+        test_db: AsyncSession,
+    ) -> dict:
+        """Helper: create a plan, add an entry with test_recipe, return GET response data."""
+        # Auto-create plan
+        resp = await client.get(
+            "/api/v1/meal-plans",
+            headers=auth_headers,
+            params={"week_start": "2025-01-06"},
+        )
+        assert resp.status_code == 200
+        plan_id = resp.json()["id"]
+
+        # Add entry via upsert
+        entry_resp = await client.put(
+            f"/api/v1/meal-plans/{plan_id}/entries",
+            headers=auth_headers,
+            json={
+                "date": "2025-01-07",
+                "meal_type": "dinner",
+                "recipe_id": test_recipe.id,
+            },
+        )
+        assert entry_resp.status_code in (200, 201)
+
+        # Re-fetch the plan to get full response
+        plan_resp = await client.get(
+            "/api/v1/meal-plans",
+            headers=auth_headers,
+            params={"week_start": "2025-01-06"},
+        )
+        assert plan_resp.status_code == 200
+        return plan_resp.json()
+
+    @pytest.mark.asyncio
+    async def test_meal_plan_entry_recipe_includes_servings(
+        self,
+        client: AsyncClient,
+        auth_headers: dict,
+        test_user,
+        test_recipe,
+        test_db: AsyncSession,
+    ):
+        """Meal plan entry recipe ref should include servings from the linked recipe."""
+        data = await self._create_plan_with_recipe_entry(
+            client, auth_headers, test_recipe, test_db
+        )
+
+        entry = data["entries"][0]
+        assert (
+            "servings" in entry["recipe"]
+        ), "Recipe ref should include 'servings' field"
+        assert entry["recipe"]["servings"] == 4
+
+    @pytest.mark.asyncio
+    async def test_meal_plan_entry_recipe_includes_difficulty_level(
+        self,
+        client: AsyncClient,
+        auth_headers: dict,
+        test_user,
+        test_recipe,
+        test_db: AsyncSession,
+    ):
+        """Meal plan entry recipe ref should include difficulty_level from the linked recipe."""
+        data = await self._create_plan_with_recipe_entry(
+            client, auth_headers, test_recipe, test_db
+        )
+
+        entry = data["entries"][0]
+        assert (
+            "difficulty_level" in entry["recipe"]
+        ), "Recipe ref should include 'difficulty_level' field"
+        assert entry["recipe"]["difficulty_level"] == "easy"
+
+    @pytest.mark.asyncio
+    async def test_meal_plan_entry_difficulty_level_is_string_not_enum(
+        self,
+        client: AsyncClient,
+        auth_headers: dict,
+        test_user,
+        test_recipe,
+        test_db: AsyncSession,
+    ):
+        """difficulty_level should be a human-readable string like 'easy', not an enum name."""
+        data = await self._create_plan_with_recipe_entry(
+            client, auth_headers, test_recipe, test_db
+        )
+
+        entry = data["entries"][0]
+        difficulty = entry["recipe"].get("difficulty_level")
+        assert isinstance(difficulty, str), "difficulty_level should be a string"
+        # Should be lowercase human-readable, not ENUM style
+        assert (
+            difficulty == difficulty.lower()
+        ), f"difficulty_level should be lowercase string, got '{difficulty}'"
+        assert difficulty in (
+            "easy",
+            "medium",
+            "hard",
+        ), f"difficulty_level should be a valid level, got '{difficulty}'"
+
+
+class TestLibraryResponseRecipeCount:
+    """Library list responses should include recipe_count."""
+
+    @pytest.mark.asyncio
+    async def test_library_list_includes_recipe_count(
+        self,
+        client: AsyncClient,
+        auth_headers: dict,
+        test_library,
+        test_recipe_in_library,
+    ):
+        """Library list response should include recipe_count matching actual recipe count."""
+        response = await client.get("/api/v1/libraries", headers=auth_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) >= 1
+
+        library = next(lib for lib in data if lib["id"] == test_library.id)
+        assert (
+            "recipe_count" in library
+        ), "Library response should include 'recipe_count' field"
+        assert library["recipe_count"] == 1
+
+    @pytest.mark.asyncio
+    async def test_library_with_no_recipes_returns_recipe_count_zero(
+        self,
+        client: AsyncClient,
+        auth_headers: dict,
+        test_library,
+    ):
+        """Library with no recipes should return recipe_count: 0."""
+        response = await client.get("/api/v1/libraries", headers=auth_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+
+        library = next(lib for lib in data if lib["id"] == test_library.id)
+        assert (
+            "recipe_count" in library
+        ), "Library response should include 'recipe_count' field"
+        assert library["recipe_count"] == 0

--- a/frontend/src/components/home/QuickActions.test.tsx
+++ b/frontend/src/components/home/QuickActions.test.tsx
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '../../test/test-utils';
+import { QuickActions } from './QuickActions';
+
+describe('QuickActions', () => {
+  it('should show "View your shopping list" for shopping action', () => {
+    render(<QuickActions />);
+
+    expect(screen.getByText('View your shopping list')).toBeInTheDocument();
+  });
+
+  it('should show "Record cooking notes" for reflection action', () => {
+    render(<QuickActions />);
+
+    expect(screen.getByText('Record cooking notes')).toBeInTheDocument();
+  });
+
+  it('should keep "Import or create new" for add recipe action', () => {
+    render(<QuickActions />);
+
+    expect(screen.getByText('Import or create new')).toBeInTheDocument();
+  });
+
+  it('should not show placeholder data in quick action descriptions', () => {
+    render(<QuickActions />);
+
+    expect(screen.queryByText('12 items across 2 stores')).not.toBeInTheDocument();
+    expect(screen.queryByText(/Pasta was too salty/)).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/home/QuickActions.tsx
+++ b/frontend/src/components/home/QuickActions.tsx
@@ -20,7 +20,7 @@ const actions: QuickAction[] = [
     to: '/shopping',
     icon: <ShoppingCart className="w-5 h-5" />,
     label: 'Go Shopping',
-    description: '12 items across 2 stores',
+    description: 'View your shopping list',
   },
   {
     to: '/recipes/create',
@@ -32,7 +32,7 @@ const actions: QuickAction[] = [
     to: '/reflections',
     icon: <MessageSquare className="w-5 h-5" />,
     label: 'Recent Reflection',
-    description: 'Pasta was too salty — noted',
+    description: 'Record cooking notes',
   },
 ];
 

--- a/frontend/src/components/meal-plan/DayColumn.test.tsx
+++ b/frontend/src/components/meal-plan/DayColumn.test.tsx
@@ -31,11 +31,23 @@ describe('DayColumn', () => {
     const entries = [
       mockMealPlanEntry({
         meal_type: 'breakfast',
-        recipe: { id: 'r1', title: 'Pancakes', cook_time_minutes: 15 },
+        recipe: {
+          id: 'r1',
+          title: 'Pancakes',
+          cook_time_minutes: 15,
+          servings: 2,
+          difficulty_level: 'easy',
+        },
       }),
       mockMealPlanEntry({
         meal_type: 'dinner',
-        recipe: { id: 'r2', title: 'Pasta', cook_time_minutes: 25 },
+        recipe: {
+          id: 'r2',
+          title: 'Pasta',
+          cook_time_minutes: 25,
+          servings: 4,
+          difficulty_level: 'medium',
+        },
       }),
     ];
 

--- a/frontend/src/pages/HomePage.mealplan.test.tsx
+++ b/frontend/src/pages/HomePage.mealplan.test.tsx
@@ -1,0 +1,348 @@
+/**
+ * Tests for Home Page - Real Meal Plan Data (Story 3, Issue #38)
+ *
+ * Verifies that the home page fetches and displays real meal plan data
+ * from the API instead of hardcoded placeholder data.
+ *
+ * These tests MUST FAIL against the current codebase (TDD RED phase)
+ * because HomePage currently uses hardcoded data.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor } from '../test/test-utils';
+import { http, HttpResponse } from 'msw';
+import { server } from '../test/mocks/server';
+import HomePage from './HomePage';
+
+const BASE_URL = 'http://localhost:8000';
+
+// Mock the auth context to return an authenticated user
+vi.mock('../contexts/AuthContext', () => ({
+  useAuth: () => ({
+    user: { id: '1', username: 'testuser', email: 'test@example.com' },
+    isLoading: false,
+    login: vi.fn(),
+    logout: vi.fn(),
+    register: vi.fn(),
+  }),
+  AuthProvider: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+// Helper: get the Monday of the current week (ISO week starts Monday)
+function getCurrentWeekMonday(): string {
+  const now = new Date();
+  const day = now.getDay(); // 0=Sun, 1=Mon, ...
+  const diff = day === 0 ? -6 : 1 - day;
+  const monday = new Date(now);
+  monday.setDate(now.getDate() + diff);
+  return monday.toISOString().split('T')[0];
+}
+
+// Helper: get today's day_of_week (0=Monday ... 6=Sunday)
+function getTodayDayOfWeek(): number {
+  const jsDay = new Date().getDay(); // 0=Sun
+  return jsDay === 0 ? 6 : jsDay - 1;
+}
+
+// Factory for a meal plan API response with entries (snake_case, matching real backend)
+function buildMealPlanResponse(
+  entries: Array<{
+    id: string;
+    day_of_week: number;
+    meal_type: string;
+    recipe: {
+      id: string;
+      title: string;
+      cook_time_minutes: number;
+      servings: number;
+      difficulty_level: string;
+    } | null;
+  }>
+) {
+  return {
+    id: 'plan-current',
+    week_start: getCurrentWeekMonday(),
+    entries,
+    created_at: '2026-01-26T00:00:00Z',
+    updated_at: '2026-01-26T00:00:00Z',
+  };
+}
+
+describe('HomePage - Real Meal Plan Data', () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      'matchMedia',
+      vi.fn().mockImplementation((query: string) => ({
+        matches: query.includes('1024'),
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      }))
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("Tonight's Dinner - API data", () => {
+    it('should display recipe name, cook time, servings, and difficulty from API', async () => {
+      const todayDow = getTodayDayOfWeek();
+
+      server.use(
+        http.get(`${BASE_URL}/api/v1/meal-plans/current`, () => {
+          return HttpResponse.json(
+            buildMealPlanResponse([
+              {
+                id: 'entry-tonight',
+                day_of_week: todayDow,
+                meal_type: 'dinner',
+                recipe: {
+                  id: 'r-salmon',
+                  title: 'Teriyaki Salmon',
+                  cook_time_minutes: 25,
+                  servings: 2,
+                  difficulty_level: 'medium',
+                },
+              },
+            ])
+          );
+        })
+      );
+
+      render(<HomePage />);
+
+      // Should show the recipe name from the API, not hardcoded "Honey Garlic Salmon"
+      await waitFor(() => {
+        expect(screen.getByText('Teriyaki Salmon')).toBeInTheDocument();
+      });
+
+      // Should show the cook time from the API
+      expect(screen.getByText(/25 min/)).toBeInTheDocument();
+
+      // Should show servings from the API
+      expect(screen.getByText(/2 servings/)).toBeInTheDocument();
+
+      // Should show difficulty from the API
+      expect(screen.getByText(/medium/i)).toBeInTheDocument();
+    });
+
+    it('should show empty state when no dinner is planned for today', async () => {
+      server.use(
+        http.get(`${BASE_URL}/api/v1/meal-plans/current`, () => {
+          return HttpResponse.json(
+            buildMealPlanResponse([
+              {
+                id: 'entry-breakfast',
+                day_of_week: getTodayDayOfWeek(),
+                meal_type: 'breakfast',
+                recipe: {
+                  id: 'r-eggs',
+                  title: 'Scrambled Eggs',
+                  cook_time_minutes: 10,
+                  servings: 2,
+                  difficulty_level: 'easy',
+                },
+              },
+            ])
+          );
+        })
+      );
+
+      render(<HomePage />);
+
+      await waitFor(() => {
+        expect(screen.getByText(/no dinner planned/i)).toBeInTheDocument();
+      });
+
+      // Should have a link to the meal plan page
+      const planLink = screen.getByRole('link', { name: /meal plan|plan dinner/i });
+      expect(planLink).toHaveAttribute('href', expect.stringContaining('/planning'));
+    });
+
+    it('should handle null recipe (entry exists but recipe was deleted)', async () => {
+      server.use(
+        http.get(`${BASE_URL}/api/v1/meal-plans/current`, () => {
+          return HttpResponse.json(
+            buildMealPlanResponse([
+              {
+                id: 'entry-deleted',
+                day_of_week: getTodayDayOfWeek(),
+                meal_type: 'dinner',
+                recipe: null,
+              },
+            ])
+          );
+        })
+      );
+
+      render(<HomePage />);
+
+      await waitFor(() => {
+        expect(screen.getByText(/no dinner planned/i)).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('This Week - 5-day rolling window', () => {
+    it('should show 5 days with correct recipe names from API', async () => {
+      const todayDow = getTodayDayOfWeek();
+
+      // Build entries for today and the next 4 days
+      const entries = [
+        {
+          id: 'e1',
+          day_of_week: todayDow,
+          meal_type: 'dinner' as const,
+          recipe: {
+            id: 'r1',
+            title: 'Pasta Bolognese',
+            cook_time_minutes: 45,
+            servings: 4,
+            difficulty_level: 'medium',
+          },
+        },
+        {
+          id: 'e2',
+          day_of_week: (todayDow + 1) % 7,
+          meal_type: 'dinner' as const,
+          recipe: {
+            id: 'r2',
+            title: 'Chicken Stir Fry',
+            cook_time_minutes: 20,
+            servings: 3,
+            difficulty_level: 'easy',
+          },
+        },
+        {
+          id: 'e3',
+          day_of_week: (todayDow + 2) % 7,
+          meal_type: 'dinner' as const,
+          recipe: {
+            id: 'r3',
+            title: 'Beef Tacos',
+            cook_time_minutes: 30,
+            servings: 4,
+            difficulty_level: 'easy',
+          },
+        },
+      ];
+
+      server.use(
+        http.get(`${BASE_URL}/api/v1/meal-plans/current`, () => {
+          return HttpResponse.json(buildMealPlanResponse(entries));
+        })
+      );
+
+      render(<HomePage />);
+
+      // Should show recipe names from the API
+      await waitFor(() => {
+        expect(screen.getByText('Pasta Bolognese')).toBeInTheDocument();
+      });
+      expect(screen.getByText('Chicken Stir Fry')).toBeInTheDocument();
+      expect(screen.getByText('Beef Tacos')).toBeInTheDocument();
+    });
+
+    it('should show "Not planned" for days without a dinner entry', async () => {
+      // Only one dinner entry for today, so days +1 through +4 have no dinner
+      server.use(
+        http.get(`${BASE_URL}/api/v1/meal-plans/current`, () => {
+          return HttpResponse.json(
+            buildMealPlanResponse([
+              {
+                id: 'e-only',
+                day_of_week: getTodayDayOfWeek(),
+                meal_type: 'dinner',
+                recipe: {
+                  id: 'r1',
+                  title: 'Grilled Chicken',
+                  cook_time_minutes: 30,
+                  servings: 4,
+                  difficulty_level: 'easy',
+                },
+              },
+            ])
+          );
+        })
+      );
+
+      render(<HomePage />);
+
+      // Wait for data to load
+      await waitFor(() => {
+        expect(screen.getByText('Grilled Chicken')).toBeInTheDocument();
+      });
+
+      // The other 4 days should show "Not planned"
+      const notPlannedItems = screen.getAllByText(/not planned/i);
+      expect(notPlannedItems.length).toBe(4);
+    });
+  });
+
+  describe('Loading state', () => {
+    it('should show skeleton loaders while meal plan data is loading', async () => {
+      // Delay the response to observe loading state
+      server.use(
+        http.get(`${BASE_URL}/api/v1/meal-plans/current`, async () => {
+          await new Promise((resolve) => setTimeout(resolve, 200));
+          return HttpResponse.json(
+            buildMealPlanResponse([
+              {
+                id: 'e1',
+                day_of_week: getTodayDayOfWeek(),
+                meal_type: 'dinner',
+                recipe: {
+                  id: 'r1',
+                  title: 'Slow Response Recipe',
+                  cook_time_minutes: 30,
+                  servings: 4,
+                  difficulty_level: 'easy',
+                },
+              },
+            ])
+          );
+        })
+      );
+
+      render(<HomePage />);
+
+      // Should show skeleton loaders immediately (before data arrives)
+      // The hardcoded "Honey Garlic Salmon" should NOT appear
+      expect(screen.queryByText('Honey Garlic Salmon')).not.toBeInTheDocument();
+
+      // Skeleton loaders should be present
+      const skeletons = screen.getAllByTestId(/skeleton/i);
+      expect(skeletons.length).toBeGreaterThan(0);
+
+      // After data loads, skeletons disappear and real content shows
+      await waitFor(() => {
+        expect(screen.getByText('Slow Response Recipe')).toBeInTheDocument();
+      });
+      expect(screen.queryAllByTestId(/skeleton/i)).toHaveLength(0);
+    });
+  });
+
+  describe('Error state', () => {
+    it("should show error message in Tonight's Dinner card when API fails", async () => {
+      server.use(
+        http.get(`${BASE_URL}/api/v1/meal-plans/current`, () => {
+          return HttpResponse.json({ detail: 'Internal server error' }, { status: 500 });
+        })
+      );
+
+      render(<HomePage />);
+
+      await waitFor(() => {
+        expect(screen.getByText(/couldn.t load|error|failed to load/i)).toBeInTheDocument();
+      });
+
+      // Should NOT show hardcoded placeholder data
+      expect(screen.queryByText('Honey Garlic Salmon')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/pages/HomePageRedesign.test.tsx
+++ b/frontend/src/pages/HomePageRedesign.test.tsx
@@ -12,7 +12,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, within } from '../test/test-utils';
+import { render, screen, within, waitFor } from '../test/test-utils';
 import userEvent from '@testing-library/user-event';
 
 import HomePage from './HomePage';
@@ -166,30 +166,36 @@ describe('HomePage Redesign', () => {
   });
 
   describe("Tonight's Dinner Card", () => {
-    it('should display difficulty in metadata', () => {
+    it('should display difficulty in metadata', async () => {
       render(<HomePage />);
 
-      expect(screen.getByText(/medium/i)).toBeInTheDocument();
+      await waitFor(() => {
+        expect(screen.getByText(/medium/i)).toBeInTheDocument();
+      });
     });
 
-    it('should have a "View Recipe" button', () => {
+    it('should have a "View Recipe" button', async () => {
       render(<HomePage />);
 
-      const viewRecipeButton = screen.getByRole('button', { name: /view recipe/i });
-      expect(viewRecipeButton).toBeInTheDocument();
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /view recipe/i })).toBeInTheDocument();
+      });
     });
 
-    it('should have a "Start Cooking" button', () => {
+    it('should have a "Start Cooking" button', async () => {
       render(<HomePage />);
 
-      const startCookingButton = screen.getByRole('button', { name: /start cooking/i });
-      expect(startCookingButton).toBeInTheDocument();
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /start cooking/i })).toBeInTheDocument();
+      });
     });
 
-    it('should show metadata with time, servings, and difficulty', () => {
+    it('should show metadata with time, servings, and difficulty', async () => {
       render(<HomePage />);
 
-      expect(screen.getByText(/35 min/)).toBeInTheDocument();
+      await waitFor(() => {
+        expect(screen.getByText(/35 min/)).toBeInTheDocument();
+      });
       expect(screen.getByText(/4 servings/)).toBeInTheDocument();
       expect(screen.getByText(/medium/i)).toBeInTheDocument();
     });
@@ -208,9 +214,9 @@ describe('HomePage Redesign', () => {
       expect(within(quickActions).getByText('Recent Reflection')).toBeInTheDocument();
 
       // Verify subtitles
-      expect(within(quickActions).getByText('12 items across 2 stores')).toBeInTheDocument();
+      expect(within(quickActions).getByText('View your shopping list')).toBeInTheDocument();
       expect(within(quickActions).getByText('Import or create new')).toBeInTheDocument();
-      expect(within(quickActions).getByText(/pasta was too salty/i)).toBeInTheDocument();
+      expect(within(quickActions).getByText('Record cooking notes')).toBeInTheDocument();
     });
 
     it('should render quick action links to correct pages', () => {

--- a/frontend/src/pages/MealPlanPage.test.tsx
+++ b/frontend/src/pages/MealPlanPage.test.tsx
@@ -90,6 +90,8 @@ describe('MealPlanPage', () => {
                     id: 'r1',
                     title: 'Scrambled Eggs',
                     cook_time_minutes: 10,
+                    servings: 2,
+                    difficulty_level: 'easy',
                   },
                 }),
               ],

--- a/frontend/src/pages/RecipesPage.test.tsx
+++ b/frontend/src/pages/RecipesPage.test.tsx
@@ -1210,38 +1210,31 @@ describe('RecipesPage', () => {
       expect(screen.getByText(/manage/i)).toBeInTheDocument();
     });
 
-    it('should render 5 collection cards', async () => {
+    it('should render collection cards from API', async () => {
       render(<RecipesPage />);
 
-      const collectionCards = screen.getAllByTestId('collection-card');
-      expect(collectionCards).toHaveLength(5);
+      await waitFor(() => {
+        const collectionCards = screen.getAllByTestId('collection-card');
+        expect(collectionCards).toHaveLength(2); // default MSW handler returns 2 libraries
+      });
     });
 
-    it('should render collection cards with names: Favorites, Quick Meals, Healthy, Party Food, New Collection', async () => {
+    it('should render collection cards with names from API', async () => {
       render(<RecipesPage />);
 
-      expect(screen.getByText('Favorites')).toBeInTheDocument();
-      expect(screen.getByText('Quick Meals')).toBeInTheDocument();
-      expect(screen.getByText('Healthy')).toBeInTheDocument();
-      expect(screen.getByText('Party Food')).toBeInTheDocument();
-      expect(screen.getByText('New Collection')).toBeInTheDocument();
+      await waitFor(() => {
+        expect(screen.getByText('Test Library')).toBeInTheDocument();
+        expect(screen.getByText('Another Library')).toBeInTheDocument();
+      });
     });
 
     it('should render collection cards with recipe counts', async () => {
       render(<RecipesPage />);
 
-      expect(screen.getByText(/12 recipes/i)).toBeInTheDocument();
-      expect(screen.getByText(/8 recipes/i)).toBeInTheDocument();
-    });
-
-    it('should use Lucide icons (SVG elements) not emoji text', async () => {
-      render(<RecipesPage />);
-
-      const collectionCards = screen.getAllByTestId('collection-card');
-      // Each collection card should contain an SVG icon
-      collectionCards.forEach((card) => {
-        const svg = card.querySelector('svg');
-        expect(svg).toBeInTheDocument();
+      await waitFor(() => {
+        // Default mock libraries both have recipeCount: 5
+        const countElements = screen.getAllByText(/5 recipes/i);
+        expect(countElements.length).toBeGreaterThanOrEqual(1);
       });
     });
   });

--- a/frontend/src/services/libraryApi.ts
+++ b/frontend/src/services/libraryApi.ts
@@ -17,14 +17,36 @@ interface LibraryDetailResponse extends RecipeLibrary {
   recipes: Recipe[];
 }
 
+interface BackendLibrary {
+  id: string;
+  name: string;
+  description: string;
+  owner_id: string;
+  is_public: boolean;
+  recipe_count: number;
+  created_at: string;
+  updated_at: string;
+}
+
+const transformLibrary = (backend: BackendLibrary): RecipeLibrary => ({
+  id: backend.id,
+  name: backend.name,
+  description: backend.description,
+  ownerId: backend.owner_id,
+  isPublic: backend.is_public,
+  recipeCount: backend.recipe_count ?? 0,
+  createdAt: backend.created_at,
+  updatedAt: backend.updated_at,
+});
+
 /**
  * Get list of user's libraries
  */
 export const getLibraries = async (skip = 0, limit = 50): Promise<RecipeLibrary[]> => {
-  const response = await apiClient.get('/api/v1/libraries', {
+  const response = await apiClient.get<BackendLibrary[]>('/api/v1/libraries', {
     params: { skip, limit },
   });
-  return response.data;
+  return response.data.map(transformLibrary);
 };
 
 /**

--- a/frontend/src/services/mealPlanApi.ts
+++ b/frontend/src/services/mealPlanApi.ts
@@ -8,7 +8,13 @@ interface BackendMealPlanResponse {
     id: string;
     day_of_week: number;
     meal_type: 'breakfast' | 'lunch' | 'dinner';
-    recipe: { id: string; title: string; cook_time_minutes: number } | null;
+    recipe: {
+      id: string;
+      title: string;
+      cook_time_minutes: number;
+      servings: number;
+      difficulty_level: string;
+    } | null;
   }[];
   created_at: string;
   updated_at: string;
@@ -28,6 +34,8 @@ function transformMealPlan(data: BackendMealPlanResponse): MealPlan {
               id: e.recipe.id,
               title: e.recipe.title,
               cookTimeMinutes: e.recipe.cook_time_minutes,
+              servings: e.recipe.servings,
+              difficultyLevel: e.recipe.difficulty_level,
             }
           : null,
       })
@@ -56,7 +64,13 @@ export async function upsertMealPlanEntry(
     id: string;
     day_of_week: number;
     meal_type: 'breakfast' | 'lunch' | 'dinner';
-    recipe: { id: string; title: string; cook_time_minutes: number } | null;
+    recipe: {
+      id: string;
+      title: string;
+      cook_time_minutes: number;
+      servings: number;
+      difficulty_level: string;
+    } | null;
   }>(`/api/v1/meal-plans/${planId}/entries`, data);
   const e = response.data;
   return {
@@ -64,7 +78,13 @@ export async function upsertMealPlanEntry(
     dayOfWeek: e.day_of_week,
     mealType: e.meal_type,
     recipe: e.recipe
-      ? { id: e.recipe.id, title: e.recipe.title, cookTimeMinutes: e.recipe.cook_time_minutes }
+      ? {
+          id: e.recipe.id,
+          title: e.recipe.title,
+          cookTimeMinutes: e.recipe.cook_time_minutes,
+          servings: e.recipe.servings,
+          difficultyLevel: e.recipe.difficulty_level,
+        }
       : null,
   };
 }

--- a/frontend/src/services/shareApi.ts
+++ b/frontend/src/services/shareApi.ts
@@ -122,6 +122,7 @@ export const getSharedLibrary = async (shareToken: string): Promise<RecipeLibrar
     description: data.description,
     ownerId: data.owner_id,
     isPublic: data.is_public,
+    recipeCount: data.recipe_count ?? 0,
     createdAt: data.created_at,
     updatedAt: data.updated_at,
   };

--- a/frontend/src/test/mocks/data.ts
+++ b/frontend/src/test/mocks/data.ts
@@ -122,6 +122,7 @@ export const mockLibrary = (overrides?: Partial<RecipeLibrary>): RecipeLibrary =
   description: 'A test library',
   isPublic: false,
   ownerId: '1',
+  recipeCount: 5,
   createdAt: new Date().toISOString(),
   updatedAt: new Date().toISOString(),
   ...overrides,

--- a/frontend/src/test/mocks/handlers.ts
+++ b/frontend/src/test/mocks/handlers.ts
@@ -138,7 +138,30 @@ export const handlers = [
 
   // Library endpoints
   http.get(`${BASE_URL}/api/v1/libraries`, async () => {
-    return HttpResponse.json([mockLibrary(), mockLibrary({ id: '2', name: 'Another Library' })]);
+    const lib1 = mockLibrary();
+    const lib2 = mockLibrary({ id: '2', name: 'Another Library' });
+    return HttpResponse.json([
+      {
+        id: lib1.id,
+        name: lib1.name,
+        description: lib1.description,
+        owner_id: lib1.ownerId,
+        is_public: lib1.isPublic,
+        recipe_count: lib1.recipeCount,
+        created_at: lib1.createdAt,
+        updated_at: lib1.updatedAt,
+      },
+      {
+        id: lib2.id,
+        name: lib2.name,
+        description: lib2.description,
+        owner_id: lib2.ownerId,
+        is_public: lib2.isPublic,
+        recipe_count: lib2.recipeCount,
+        created_at: lib2.createdAt,
+        updated_at: lib2.updatedAt,
+      },
+    ]);
   }),
 
   http.get(`${BASE_URL}/api/v1/libraries/:id`, async ({ params }) => {

--- a/frontend/src/test/mocks/mealPlanData.ts
+++ b/frontend/src/test/mocks/mealPlanData.ts
@@ -7,6 +7,8 @@ export interface MockMealPlanRecipe {
   id: string;
   title: string;
   cook_time_minutes: number;
+  servings: number;
+  difficulty_level: string;
 }
 
 export interface MockMealPlanEntry {
@@ -24,6 +26,12 @@ export interface MockMealPlanWeek {
   updated_at: string;
 }
 
+// Get today's day_of_week in Python format (Monday=0, Sunday=6)
+function getTodayDow(): number {
+  const jsDay = new Date().getDay();
+  return jsDay === 0 ? 6 : jsDay - 1;
+}
+
 export const mockMealPlanEntry = (overrides?: Partial<MockMealPlanEntry>): MockMealPlanEntry => ({
   id: 'entry-1',
   day_of_week: 0,
@@ -32,6 +40,8 @@ export const mockMealPlanEntry = (overrides?: Partial<MockMealPlanEntry>): MockM
     id: 'r1',
     title: 'Test Meal',
     cook_time_minutes: 20,
+    servings: 2,
+    difficulty_level: 'easy',
   },
   ...overrides,
 });
@@ -44,13 +54,38 @@ export const mockMealPlanWeek = (overrides?: Partial<MockMealPlanWeek>): MockMea
       id: 'entry-1',
       day_of_week: 0,
       meal_type: 'breakfast',
-      recipe: { id: 'r1', title: 'Scrambled Eggs', cook_time_minutes: 10 },
+      recipe: {
+        id: 'r1',
+        title: 'Scrambled Eggs',
+        cook_time_minutes: 10,
+        servings: 2,
+        difficulty_level: 'easy',
+      },
     }),
     mockMealPlanEntry({
       id: 'entry-2',
       day_of_week: 2,
       meal_type: 'dinner',
-      recipe: { id: 'r2', title: 'Grilled Chicken', cook_time_minutes: 30 },
+      recipe: {
+        id: 'r2',
+        title: 'Grilled Chicken',
+        cook_time_minutes: 30,
+        servings: 4,
+        difficulty_level: 'medium',
+      },
+    }),
+    // Today's dinner - ensures HomePage tests that expect dinner data work
+    mockMealPlanEntry({
+      id: 'entry-today-dinner',
+      day_of_week: getTodayDow(),
+      meal_type: 'dinner',
+      recipe: {
+        id: 'r-today',
+        title: 'Honey Garlic Salmon',
+        cook_time_minutes: 35,
+        servings: 4,
+        difficulty_level: 'medium',
+      },
     }),
   ],
   created_at: new Date().toISOString(),

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -59,6 +59,7 @@ export interface RecipeLibrary {
   description: string;
   ownerId: string;
   isPublic: boolean;
+  recipeCount: number;
   createdAt: string;
   updatedAt: string;
 }

--- a/frontend/src/types/mealPlan.ts
+++ b/frontend/src/types/mealPlan.ts
@@ -4,6 +4,8 @@ export interface MealPlanRecipe {
   id: string;
   title: string;
   cookTimeMinutes: number;
+  servings: number;
+  difficultyLevel: string;
 }
 
 export interface MealPlanEntry {


### PR DESCRIPTION
## Summary
- Enrich seed script with libraries, meal plans, idempotency, and `make seed`/`make seed-reset` targets
- Add `servings`, `difficulty_level` to meal plan API responses; `recipe_count` to library API responses
- Home page fetches real meal plan data with skeleton loaders, error states, and empty states
- Quick actions show honest descriptions instead of fake placeholder counts
- Cookbook shows real collections from the libraries API with loading/error/empty states
- Add `RESET=1` option to `make dev-backend`/`make dev-frontend` for clean restarts

Closes #38

## Test plan
- [ ] Backend: 244 tests pass (`make test-backend`)
- [ ] Frontend: 844 tests pass (`make test-frontend`)
- [ ] Run `make seed` and verify demo data populates correctly
- [ ] Visual: Home page shows real meal plan data or empty states
- [ ] Visual: Cookbook shows real collections or empty state
- [ ] Visual: Quick actions show honest descriptions

🤖 Generated with [Claude Code](https://claude.com/claude-code)